### PR TITLE
Fix package hash and unfree license in flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,10 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
       in
       {
         packages = {

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -27,7 +27,7 @@ let
   # Update these values when a new version is released.
   # Run packaging/nix/update-hash.sh to compute the new hash.
   version = "1.1.3918";
-  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  hash = "sha256-oVesBRJ9g32EyZzncKpBUstIm0mylNaWr+9oJMLSOCs=";
 in
 stdenvNoCC.mkDerivation {
   pname = "claude-desktop-bin";


### PR DESCRIPTION
## Summary

- **Fix placeholder hash in `package.nix`**: Replace the dummy `sha256-AAA...` with the correct hash for v1.1.3918, which prevents the package from building at all.
- **Fix unfree license evaluation in `flake.nix`**: `nixpkgs.legacyPackages` creates a pkgs instance with default config (`allowUnfree = false`). Since the package declares `license = licenses.unfree`, any consumer using the flake output gets `"has an unfree license, refusing to evaluate"` — even if their own NixOS config has `allowUnfree = true`. Switching to `import nixpkgs { config.allowUnfree = true; }` fixes this.

## Changes

### `packaging/nix/package.nix`
```diff
- hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+ hash = "sha256-oVesBRJ9g32EyZzncKpBUstIm0mylNaWr+9oJMLSOCs=";
```

### `flake.nix`
```diff
- pkgs = nixpkgs.legacyPackages.${system};
+ pkgs = import nixpkgs {
+   inherit system;
+   config.allowUnfree = true;
+ };
```

## Reproduction

Without this fix, adding the flake as an input and building fails:

```
error: Package 'claude-desktop-bin-1.1.3918' has an unfree license ('unfree'), refusing to evaluate.
```

And even if the license check is bypassed, the build fails due to the placeholder hash:

```
error: hash mismatch in fixed-output derivation
  specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
  got:       sha256-oVesBRJ9g32EyZzncKpBUstIm0mylNaWr+9oJMLSOCs=
```

## Test plan

- [ ] `nix build github:soy-oreocato/claude-desktop-bin/fix/flake-unfree-and-hash` succeeds
- [ ] The resulting `claude-desktop` binary launches correctly
- [ ] Consuming the flake as an input with `inputs.nixpkgs.follows = "nixpkgs"` works without hash or license errors