### PR TITLE
feat(nix): make extraSessionPaths override claude-code in wrapper PATH

### DIFF
--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -18,15 +18,19 @@
 , wl-clipboard ? null   # clipboard access
 , wlr-randr ? null      # display enumeration (wlroots)
 , hyprland ? null       # cursor positioning (Hyprland only)
+# Claude Code CLI — required for Cowork, Dispatch, and Code integration
+, claude-code ? null    # auto-resolved by callPackage if in nixpkgs
 # Other optional
 , socat ? null          # cowork socket health check
 , nodejs ? null         # third-party MCP servers
+# Extra PATH entries for binaries not packaged in Nix (e.g. npm global, nvm)
+, extraSessionPaths ? []
 }:
 
 let
   # Updated automatically by CI (update-aur.yml) on each release.
   version = "1.1.9310";
-  hash = "sha256-YXFNeQe093xsUf/q4Lm2hDEh76eFWDn7N3j1OzxbcZw=";
+  hash = "sha256-iACaRhsjvpdQoKcS3tLI3sUGtdZWohxeaNo3hLIfINI=";
 in
 stdenvNoCC.mkDerivation {
   pname = "claude-desktop-bin";
@@ -82,6 +86,11 @@ stdenvNoCC.mkDerivation {
       ${lib.optionalString (wl-clipboard != null) "--prefix PATH : ${wl-clipboard}/bin"} \
       ${lib.optionalString (wlr-randr != null) "--prefix PATH : ${wlr-randr}/bin"} \
       ${lib.optionalString (nodejs != null) "--prefix PATH : ${nodejs}/bin"} \
+      ${lib.optionalString (claude-code != null && extraSessionPaths == []) "--prefix PATH : ${claude-code}/bin"} \
+      ${lib.concatMapStringsSep " \\\n      " (p:
+        let path = if builtins.isString p then p else "${p}/bin";
+        in "--prefix PATH : ${path}"
+      ) extraSessionPaths} \
       --add-flags "$out/lib/claude-desktop/resources/app.asar"
 
     # Install icon


### PR DESCRIPTION
## Problem

Dispatch was not showing up in Claude Desktop/Cowork on NixOS. Mobile-to-desktop messages were delivered but Claude never responded — the Cowork service silently failed when trying to spawn the `claude` CLI.

## Diagnosis

The Cowork service spawns `claude` as a subprocess, but the Electron wrapper wasn't resolving the correct binary. On NixOS, `callPackage` auto-resolves `claude-code` from nixpkgs, injecting an outdated version (e.g. v2.1.25) into PATH. When a user also provides `extraSessionPaths` pointing to a newer install (e.g. npm global with v2.1.85), both paths end up in the wrapper. Since `--prefix PATH` prepends, the **nixpkgs version wins** — even when it's incompatible with the current SDK (e.g. missing `--effort` flag support).

## Solution

The wrapper now verifies `claude-code` from nixpkgs first as the default zero-config path, but gives the user the ability to override it with `extraSessionPaths`:

```nix
${lib.optionalString (claude-code != null && extraSessionPaths == []) "--prefix PATH : ${claude-code}/bin"}
```

| `claude-code` in nixpkgs | `extraSessionPaths` | Result |
|---|---|---|
| Available | `[]` | Uses nixpkgs `claude-code` (zero-config) |
| Available | Non-empty | Ignores nixpkgs, uses `extraSessionPaths` |
| Not available | Any | Uses `extraSessionPaths` if provided |

### Usage

Zero-config (nixpkgs claude-code is sufficient):
```nix
claude-desktop  # callPackage auto-resolves claude-code
```

Override with custom path:
```nix
claude-desktop.override {
  extraSessionPaths = [ "/home/user/.npm-global/bin" ];
}
```

## Test plan

- [x] Tested on NixOS 25.11 with `extraSessionPaths` pointing to npm-global install
- [x] Dispatch end-to-end working (mobile → Claude Desktop → Cowork → claude CLI)
- [x] Cowork responding correctly with latest claude CLI