### PR TITLE
Add XDG portal screenshot support for GNOME Wayland with token persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This is an AUR package that repackages Claude Desktop (Windows) for Arch Linux. 
 |-------------|-------------------|---------------|-----------------|
 | X11 | Any (GNOME, KDE, i3, …) | `xdotool` | `scrot`, `imagemagick`, `gnome-screenshot` |
 | Wayland — wlroots | Sway, Hyprland | `ydotool` (+`ydotoold`) | `grim` |
-| Wayland — GNOME | GNOME Shell | `ydotool` (+`ydotoold`) | `gdbus` (glib2), `gnome-screenshot` fallback |
+| Wayland — GNOME | GNOME Shell | `ydotool` (+`ydotoold`) | Portal+PipeWire (restore token), `gdbus` (glib2), `gnome-screenshot` fallback |
 | Wayland — KDE | KDE Plasma | `ydotool` (+`ydotoold`) | `spectacle`, `imagemagick` (crop) |
 | XWayland | Any Wayland compositor | `xdotool` (fallback) | depends on compositor |
 

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -22,6 +22,8 @@ optdepends=('nodejs: System Node.js for MCP extensions that require specific ver
             'jq: Computer Use window queries on Sway (used with swaymsg)'
             'spectacle: Computer Use screenshots (KDE Plasma Wayland)'
             'glib2: Computer Use screenshots on GNOME Wayland (gdbus for D-Bus)'
+            'python-gobject: Portal screenshots on GNOME Wayland with PipeWire restore tokens (no repeated permission dialogs)'
+            'gst-plugin-pipewire: Portal screenshot PipeWire frame capture on GNOME Wayland'
             'gnome-screenshot: Computer Use screenshot fallback (GNOME)'
             'hyprland: Quick Entry cursor positioning on Hyprland Wayland (hyprctl)'
             'socat: Cowork socket health check in launcher (fallback: age-based check)')

--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ Claude Desktop works without these — features degrade gracefully when tools ar
 | Operation | X11 / XWayland | Wayland — wlroots (Sway, Hyprland) | Wayland — GNOME | Wayland — KDE Plasma |
 |-----------|---------------|-------------------------------------|-----------------|----------------------|
 | Input automation | `xdotool` | `ydotool` (+ `ydotoold` running) | `ydotool` (+ `ydotoold` running) | `ydotool` (+ `ydotoold` running) |
-| Screenshots | `scrot`, `imagemagick` | `grim` | `gdbus` (glib2), `gnome-screenshot` | `spectacle`, `imagemagick` |
+| Screenshots | `scrot`, `imagemagick` | `grim` | Portal+PipeWire (preferred), `gdbus` (glib2), `gnome-screenshot` | `spectacle`, `imagemagick` |
 | Clipboard | Electron API (built-in) | Electron API (built-in) | Electron API (built-in) | Electron API (built-in) |
 | Display info | Electron API (built-in) | Electron API (built-in) | Electron API (built-in) | Electron API (built-in) |
 | Window queries | `wmctrl` | `swaymsg` (Sway), `jq` | — | — |
 | Cursor positioning | `xdotool` | `ydotool` | `xdotool` (read), `ydotool` (move) | `xdotool` (read), `ydotool` (move) |
 
-> **GNOME:** `gdbus` (from glib2/libglib2.0-bin) provides the `org.gnome.Shell.Screenshot` D-Bus interface. `gnome-screenshot` is a fallback if D-Bus fails.
+> **GNOME:** On GNOME 46+/Ubuntu 25.10+, the preferred method uses the XDG ScreenCast portal with PipeWire restore tokens — the first screenshot shows a permission dialog, but all subsequent screenshots are silent (requires `python3-gi`/`python-gobject` and `gst-plugin-pipewire`). Falls back to `gdbus` (from glib2/libglib2.0-bin) which provides the `org.gnome.Shell.Screenshot` D-Bus interface. `gnome-screenshot` is a last-resort fallback. The restore token is stored in `~/.config/Claude/pipewire-restore-token`.
 >
 > **KDE:** `spectacle` captures screenshots. `imagemagick` (`convert`) crops to monitor region on multi-monitor setups.
 >
@@ -363,7 +363,7 @@ The package applies several patches to make Claude Desktop work on Linux. Each p
 | `fix_browse_files_linux.py` | Enables `openDirectory` in file dialog (upstream macOS-only) | `rg -o 'openDirectory.{0,60}' index.js` |
 | `fix_browser_tools_linux.py` | Enables Chrome browser tools — redirects native host to Claude Code's wrapper | `rg -o '"Helpers".{0,50}' index.js` |
 | `fix_claude_code.py` | Detects system-installed Claude Code binary | `rg -o 'async getStatus\(\)\{.{0,200}' index.js` |
-| `fix_computer_use_linux.py` | Enables Computer Use — removes platform gates, injects Linux executor (grim/GNOME D-Bus/spectacle/scrot, xdotool/ydotool) | `rg -o 'process.platform.*darwin.*t7r' index.js` |
+| `fix_computer_use_linux.py` | Enables Computer Use — removes platform gates, injects Linux executor (portal+PipeWire/grim/GNOME D-Bus/spectacle/scrot, xdotool/ydotool) | `rg -o 'process.platform.*darwin.*t7r' index.js` |
 | `fix_computer_use_tcc.py` | Stubs macOS TCC permission handlers to prevent error logs | Prepended IIFE, UUID extraction |
 | `fix_cowork_error_message.py` | Replaces Windows VM errors with Linux-friendly guidance | String literal match |
 | `fix_cowork_linux.py` | Enables Cowork — VM client, Unix socket, bundle config, binary resolution | `rg -o '.{0,50}vmClient.{0,50}' index.js` |

--- a/patches/fix_computer_use_linux.py
+++ b/patches/fix_computer_use_linux.py
@@ -59,6 +59,106 @@ function _desktopId(){return(process.env.XDG_CURRENT_DESKTOP||"").toLowerCase()}
 var _ydotoolOk=null;
 function _checkYdotool(){if(_ydotoolOk!==null)return _ydotoolOk;if(!_hasCmd("ydotool")){_ydotoolOk=false;return false}try{_cp.execSync("pgrep -x ydotoold",{timeout:2000,stdio:"pipe"});_ydotoolOk=true}catch(e){var sock=(process.env.YDOTOOL_SOCKET||"")||((process.env.XDG_RUNTIME_DIR||"/tmp")+"/.ydotool_socket");try{_fs.accessSync(sock);_ydotoolOk=true}catch(se){console.warn("[claude-cu] ydotool found but ydotoold not running — falling back to xdotool");_ydotoolOk=false}}return _ydotoolOk}
 function _readClean(f){var buf=_fs.readFileSync(f);try{_fs.unlinkSync(f)}catch(e){}return buf.toString("base64")}
+var _portalScriptDir=_path.join(_os.homedir(),".config","Claude");
+var _portalScriptPath=_path.join(_portalScriptDir,"gnome-portal-screenshot.py");
+var _portalScriptContent='#!/usr/bin/env python3\n\
+# XDG ScreenCast portal screenshot with PipeWire restore token.\n\
+import sys,os,signal,subprocess\n\
+TOKEN_FILE=os.path.expanduser("~/.config/Claude/pipewire-restore-token")\n\
+def main():\n\
+    if len(sys.argv)<2: return 1\n\
+    out=sys.argv[1]; crop=tuple(int(x) for x in sys.argv[2:6]) if len(sys.argv)>=6 else None\n\
+    try:\n\
+        import gi; gi.require_version("Gst","1.0")\n\
+        from gi.repository import GLib,Gio,Gst\n\
+    except (ImportError,ValueError) as e:\n\
+        print(f"[portal-screenshot] missing deps: {e}",file=sys.stderr); return 2\n\
+    Gst.init(None)\n\
+    tok=""\n\
+    try:\n\
+        with open(TOKEN_FILE) as f: tok=f.read().strip()\n\
+    except FileNotFoundError: pass\n\
+    bus=Gio.bus_get_sync(Gio.BusType.SESSION); loop=GLib.MainLoop()\n\
+    S={"nd":None,"tk":"","sess":"","err":None,"done":False}\n\
+    un=bus.get_unique_name().replace(".","_").replace(":",""); c=[0]\n\
+    def nt():\n\
+        c[0]+=1; return f"claude_{os.getpid()}_{c[0]}"\n\
+    def sub(hp,cb):\n\
+        sid=[None]\n\
+        def _h(cn,sn,p,i,sg,pr): bus.signal_unsubscribe(sid[0]); r,res=pr.unpack(); cb(r,res)\n\
+        sid[0]=bus.signal_subscribe("org.freedesktop.portal.Desktop","org.freedesktop.portal.Request","Response",hp,None,0,_h); return sid[0]\n\
+    def pcall(method,av):\n\
+        return bus.call_sync("org.freedesktop.portal.Desktop","/org/freedesktop/portal/desktop","org.freedesktop.portal.ScreenCast",method,av,None,0,15000,None)\n\
+    def fail(m): S["err"]=m; loop.quit() if loop.is_running() else None\n\
+    def do_start():\n\
+        ht=nt(); hp=f"/org/freedesktop/portal/desktop/request/{un}/{ht}"\n\
+        def _s(r,res):\n\
+            if r!=0: fail(f"Start rejected ({r})"); return\n\
+            st=res.get("streams",None); ntk=res.get("restore_token","")\n\
+            if ntk: S["tk"]=ntk\n\
+            if st:\n\
+                sl=st.unpack() if hasattr(st,"unpack") else st\n\
+                if sl: S["nd"]=sl[0][0] if isinstance(sl[0],tuple) else sl[0]\n\
+            S["done"]=True; loop.quit()\n\
+        sub(hp,_s); pcall("Start",GLib.Variant("(osa{sv})",(S["sess"],"",{"handle_token":GLib.Variant("s",ht)})))\n\
+    def do_select():\n\
+        ht=nt(); hp=f"/org/freedesktop/portal/desktop/request/{un}/{ht}"\n\
+        def _s(r,res):\n\
+            if r!=0: fail(f"SelectSources rejected ({r})"); return\n\
+            do_start()\n\
+        sub(hp,_s); opts={"handle_token":GLib.Variant("s",ht),"types":GLib.Variant("u",1),"multiple":GLib.Variant("b",False),"persist_mode":GLib.Variant("u",2)}\n\
+        if tok: opts["restore_token"]=GLib.Variant("s",tok)\n\
+        pcall("SelectSources",GLib.Variant("(oa{sv})",(S["sess"],opts)))\n\
+    def do_create():\n\
+        ht=nt(); st=f"claude_sess_{os.getpid()}"; hp=f"/org/freedesktop/portal/desktop/request/{un}/{ht}"\n\
+        def _c2(r,res):\n\
+            if r!=0: fail(f"CreateSession rejected ({r})"); return\n\
+            sh=res.get("session_handle","")\n\
+            if not sh: fail("No session handle"); return\n\
+            S["sess"]=sh; do_select()\n\
+        sub(hp,_c2); pcall("CreateSession",GLib.Variant("(a{sv})",({"handle_token":GLib.Variant("s",ht),"session_handle_token":GLib.Variant("s",st)},)))\n\
+    GLib.timeout_add_seconds(15,lambda:(fail("timeout") if not S["done"] else None,False)[-1])\n\
+    try: do_create(); loop.run()\n\
+    except Exception as e: fail(str(e))\n\
+    if S["err"]: print("[portal-screenshot] "+S["err"],file=sys.stderr); return 1\n\
+    if not S["nd"]: print("[portal-screenshot] no PipeWire node",file=sys.stderr); return 1\n\
+    if S["tk"]:\n\
+        try: os.makedirs(os.path.dirname(TOKEN_FILE),exist_ok=True); open(TOKEN_FILE,"w").write(S["tk"])\n\
+        except: pass\n\
+    nd=S["nd"]\n\
+    try:\n\
+        p=Gst.parse_launch(f\'pipewiresrc path={nd} num-buffers=3 ! videorate ! video/x-raw,framerate=1/1 ! videoconvert ! pngenc ! filesink location="{out}"\')\n\
+        p.set_state(Gst.State.PLAYING); gb=p.get_bus()\n\
+        msg=gb.timed_pop_filtered(10*Gst.SECOND,Gst.MessageType.EOS|Gst.MessageType.ERROR)\n\
+        if msg and msg.type==Gst.MessageType.ERROR: e,_=msg.parse_error(); print(f"[portal-screenshot] GStreamer: {e.message}",file=sys.stderr); p.set_state(Gst.State.NULL); return 1\n\
+        p.set_state(Gst.State.NULL)\n\
+    except Exception as e:\n\
+        print(f"[portal-screenshot] GStreamer failed: {e}",file=sys.stderr); return 1\n\
+    if not os.path.exists(out): return 1\n\
+    if crop:\n\
+        cx,cy,cw,ch=crop\n\
+        try:\n\
+            from gi.repository import GdkPixbuf\n\
+            pb=GdkPixbuf.Pixbuf.new_from_file(out); pw,ph=pb.get_width(),pb.get_height()\n\
+            cx=min(cx,pw-1);cy=min(cy,ph-1);cw=min(cw,pw-cx);ch=min(ch,ph-cy)\n\
+            cr=GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB,pb.get_has_alpha(),8,cw,ch)\n\
+            pb.copy_area(cx,cy,cw,ch,cr,0,0); cr.savev(out,"png",[],[])\n\
+        except ImportError:\n\
+            try: subprocess.run(["convert",out,"-crop",f"{cw}x{ch}+{cx}+{cy}","+repage",out],timeout=5,check=True,capture_output=True)\n\
+            except: pass\n\
+    if S["sess"]:\n\
+        try: bus.call_sync("org.freedesktop.portal.Desktop",S["sess"],"org.freedesktop.portal.Session","Close",None,None,0,1000,None)\n\
+        except: pass\n\
+    return 0\n\
+if __name__=="__main__":\n\
+    signal.signal(signal.SIGALRM,lambda *_:sys.exit(1)); signal.alarm(20); sys.exit(main())\n';
+var _portalScriptReady=false;
+function _ensurePortalScript(){
+  if(_portalScriptReady)return true;
+  try{_fs.mkdirSync(_portalScriptDir,{recursive:true})}catch(e){}
+  try{_fs.writeFileSync(_portalScriptPath,_portalScriptContent,{mode:0o755});_portalScriptReady=true;return true}catch(e){console.warn("[claude-cu] could not write portal screenshot script: "+e.message);return false}
+}
+function _hasPortalDeps(){return _hasCmd("python3")&&_hasCmd("gst-launch-1.0")}
 async function _captureRegion(x,y,w,h){
   var tmp=_path.join(_os.tmpdir(),"claude-cu-"+Date.now()+"-"+Math.random().toString(36).slice(2)+".png");
   var _de=_desktopId();
@@ -68,6 +168,12 @@ async function _captureRegion(x,y,w,h){
   }
   if(_wayland&&_isWlroots()&&_hasCmd("grim")){
     try{_cp.execSync('grim -g "'+x+","+y+" "+w+"x"+h+'" "'+tmp+'"',{timeout:10000});console.log("[claude-cu] screenshot: captured via grim (wlroots)");return _readClean(tmp)}catch(e){console.warn("[claude-cu] grim failed: "+e.message)}
+  }
+  if(_wayland&&_de.indexOf("gnome")>=0&&_hasPortalDeps()&&_ensurePortalScript()){
+    try{var ret=_cp.spawnSync("python3",[_portalScriptPath,tmp,String(x),String(y),String(w),String(h)],{timeout:25000,stdio:["ignore","pipe","pipe"]});
+    if(ret.status===0&&_fs.existsSync(tmp)){console.log("[claude-cu] screenshot: captured via portal+pipewire (GNOME, restore token)");return _readClean(tmp)}
+    if(ret.status===2){console.warn("[claude-cu] portal screenshot: missing python deps (python3-gi, gstreamer)")}
+    else{console.warn("[claude-cu] portal screenshot failed (exit="+ret.status+"): "+(ret.stderr?ret.stderr.toString().trim():""))}}catch(e){console.warn("[claude-cu] portal screenshot error: "+e.message)}
   }
   if(_wayland&&_de.indexOf("gnome")>=0&&_hasCmd("gdbus")){
     try{_cp.execSync("gdbus call --session --dest org.gnome.Shell.Screenshot --object-path /org/gnome/Shell/Screenshot --method org.gnome.Shell.Screenshot.ScreenshotArea "+x+" "+y+" "+w+" "+h+" false '"+tmp+"'",{timeout:10000});
@@ -96,7 +202,7 @@ if(_wayland){console.log("[claude-cu] Wayland session detected — using native 
   var _isHypr=!!process.env.HYPRLAND_INSTANCE_SIGNATURE;var _isSway=!!process.env.SWAYSOCK;
   var _relevant=[];
   if(_wayland&&_wlr)_relevant.push("grim");
-  if(_wayland&&_isGnome)_relevant.push("gdbus");
+  if(_wayland&&_isGnome){_relevant.push("python3","gst-launch-1.0");_relevant.push("gdbus")}
   if(_isKde){_relevant.push("spectacle");_relevant.push("convert")}
   if(!_wayland&&_isGnome)_relevant.push("gnome-screenshot");
   if(!_wayland)_relevant.push("scrot","import");
@@ -120,6 +226,7 @@ if(_wayland){console.log("[claude-cu] Wayland session detected — using native 
   var order=[];
   if(process.env.COWORK_SCREENSHOT_CMD)order.push("COWORK_SCREENSHOT_CMD");
   if(_wayland&&_wlr&&_hasCmd("grim"))order.push("grim");
+  if(_wayland&&_isGnome&&_hasPortalDeps())order.push("portal+pipewire");
   if(_wayland&&_isGnome&&_hasCmd("gdbus"))order.push("gdbus");
   if(_isKde&&_hasCmd("spectacle"))order.push("spectacle");
   if(!_wayland&&_isGnome&&_hasCmd("gnome-screenshot"))order.push("gnome-screenshot");
@@ -127,6 +234,7 @@ if(_wayland){console.log("[claude-cu] Wayland session detected — using native 
   if(!_wayland&&_hasCmd("import"))order.push("import");
   order.push("desktopCapturer");
   console.log("[claude-cu] diagnostics: screenshot-cascade=["+order.join(" > ")+"]");
+  if(_wayland&&_isGnome){try{_fs.accessSync(_path.join(_os.homedir(),".config","Claude","pipewire-restore-token"));console.log("[claude-cu] diagnostics: pipewire-restore-token=found (portal screenshots will skip permission dialog)")}catch(e){console.log("[claude-cu] diagnostics: pipewire-restore-token=none (first portal screenshot will show permission dialog)")}}
 })();
 var _defaultMon={displayId:0,width:1920,height:1080,originX:0,originY:0,scaleFactor:1,isPrimary:true,label:"default"};
 function _getMonitors(){

--- a/scripts/gnome-portal-screenshot.py
+++ b/scripts/gnome-portal-screenshot.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+XDG ScreenCast portal screenshot with PipeWire restore token support.
+
+On GNOME Wayland (46+), the org.gnome.Shell.Screenshot D-Bus interface is
+restricted and Electron's desktopCapturer triggers a portal permission dialog
+on every screenshot. This script uses the ScreenCast portal with restore tokens:
+first invocation shows the permission dialog, subsequent invocations reuse the
+saved token and capture silently.
+
+Usage: gnome-portal-screenshot.py <output.png> [x y w h]
+Exit codes: 0=success, 1=capture error, 2=missing dependencies
+"""
+
+import sys
+import os
+import signal
+import subprocess
+
+TOKEN_FILE = os.path.expanduser("~/.config/Claude/pipewire-restore-token")
+TIMEOUT_SECS = 15
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: gnome-portal-screenshot.py <output.png> [x y w h]",
+              file=sys.stderr)
+        return 1
+
+    output_path = sys.argv[1]
+    crop = None
+    if len(sys.argv) >= 6:
+        crop = tuple(int(x) for x in sys.argv[2:6])
+
+    try:
+        import gi
+        gi.require_version('Gst', '1.0')
+        from gi.repository import GLib, Gio, Gst
+    except (ImportError, ValueError) as e:
+        print(f"[portal-screenshot] missing deps: {e}", file=sys.stderr)
+        return 2
+
+    Gst.init(None)
+
+    # Load saved restore token
+    restore_token = ""
+    try:
+        with open(TOKEN_FILE) as f:
+            restore_token = f.read().strip()
+    except FileNotFoundError:
+        pass
+
+    bus = Gio.bus_get_sync(Gio.BusType.SESSION)
+    loop = GLib.MainLoop()
+    state = {
+        "node_id": None,
+        "new_token": "",
+        "session": None,
+        "error": None,
+        "done": False,
+    }
+
+    unique = bus.get_unique_name().replace(".", "_").replace(":", "")
+    counter = [0]
+
+    def next_token():
+        counter[0] += 1
+        return f"claude_{os.getpid()}_{counter[0]}"
+
+    def subscribe_response(handle_path, callback):
+        """Subscribe to portal Response signal, auto-unsubscribe on receipt."""
+        sub = [None]
+
+        def on_signal(conn, sender, path, iface, sig_name, params):
+            bus.signal_unsubscribe(sub[0])
+            resp, results = params.unpack()
+            callback(resp, results)
+
+        sub[0] = bus.signal_subscribe(
+            "org.freedesktop.portal.Desktop",
+            "org.freedesktop.portal.Request",
+            "Response",
+            handle_path,
+            None,
+            Gio.DBusSignalFlags.NO_MATCH_RULE,
+            on_signal,
+        )
+        return sub[0]
+
+    def portal_call(method, args_variant):
+        """Call a ScreenCast portal method."""
+        return bus.call_sync(
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.ScreenCast",
+            method,
+            args_variant,
+            None,
+            Gio.DBusCallFlags.NONE,
+            TIMEOUT_SECS * 1000,
+            None,
+        )
+
+    def fail(msg):
+        state["error"] = msg
+        if loop.is_running():
+            loop.quit()
+
+    # Step 3: Start the session (may show dialog if no valid restore token)
+    def do_start():
+        ht = next_token()
+        handle = f"/org/freedesktop/portal/desktop/request/{unique}/{ht}"
+
+        def on_start(resp, results):
+            if resp != 0:
+                fail(f"Start rejected (response={resp})")
+                return
+            # Extract PipeWire streams
+            streams = results.get("streams", None)
+            new_token = results.get("restore_token", "")
+            if new_token:
+                state["new_token"] = new_token
+            if streams:
+                # streams is a(ua{sv}) — list of (node_id, properties)
+                stream_list = streams.unpack() if hasattr(streams, 'unpack') else streams
+                if stream_list:
+                    first = stream_list[0]
+                    state["node_id"] = first[0] if isinstance(first, tuple) else first
+            state["done"] = True
+            loop.quit()
+
+        subscribe_response(handle, on_start)
+
+        portal_call("Start", GLib.Variant("(osa{sv})", (
+            state["session"],
+            "",  # parent_window
+            {"handle_token": GLib.Variant("s", ht)},
+        )))
+
+    # Step 2: SelectSources (monitor, persist mode, restore token)
+    def do_select():
+        ht = next_token()
+        handle = f"/org/freedesktop/portal/desktop/request/{unique}/{ht}"
+
+        def on_select(resp, results):
+            if resp != 0:
+                fail(f"SelectSources rejected (response={resp})")
+                return
+            do_start()
+
+        subscribe_response(handle, on_select)
+
+        opts = {
+            "handle_token": GLib.Variant("s", ht),
+            "types": GLib.Variant("u", 1),           # MONITOR
+            "multiple": GLib.Variant("b", False),
+            "persist_mode": GLib.Variant("u", 2),     # until explicitly revoked
+        }
+        if restore_token:
+            opts["restore_token"] = GLib.Variant("s", restore_token)
+
+        portal_call("SelectSources", GLib.Variant("(oa{sv})", (
+            state["session"],
+            opts,
+        )))
+
+    # Step 1: CreateSession
+    def do_create():
+        ht = next_token()
+        st = f"claude_sess_{os.getpid()}"
+        handle = f"/org/freedesktop/portal/desktop/request/{unique}/{ht}"
+
+        def on_create(resp, results):
+            if resp != 0:
+                fail(f"CreateSession rejected (response={resp})")
+                return
+            session_handle = results.get("session_handle", "")
+            if not session_handle:
+                fail("No session handle returned")
+                return
+            state["session"] = session_handle
+            do_select()
+
+        subscribe_response(handle, on_create)
+
+        portal_call("CreateSession", GLib.Variant("(a{sv})", ({
+            "handle_token": GLib.Variant("s", ht),
+            "session_handle_token": GLib.Variant("s", st),
+        },)))
+
+    # Timeout guard
+    def on_timeout():
+        if not state["done"]:
+            fail("Timed out waiting for portal response")
+        return False
+
+    GLib.timeout_add_seconds(TIMEOUT_SECS, on_timeout)
+
+    # Kick off the portal session chain
+    try:
+        do_create()
+        loop.run()
+    except Exception as e:
+        fail(str(e))
+
+    if state["error"]:
+        print(f"[portal-screenshot] {state['error']}", file=sys.stderr)
+        return 1
+
+    if not state["node_id"]:
+        print("[portal-screenshot] no PipeWire node ID received", file=sys.stderr)
+        return 1
+
+    # Save restore token for next time (no more dialogs)
+    if state["new_token"]:
+        try:
+            os.makedirs(os.path.dirname(TOKEN_FILE), exist_ok=True)
+            with open(TOKEN_FILE, "w") as f:
+                f.write(state["new_token"])
+            print("[portal-screenshot] restore token saved", file=sys.stderr)
+        except OSError as e:
+            print(f"[portal-screenshot] warning: could not save token: {e}",
+                  file=sys.stderr)
+
+    # Capture a frame from PipeWire via GStreamer
+    node_id = state["node_id"]
+    try:
+        pipeline = Gst.parse_launch(
+            f'pipewiresrc path={node_id} num-buffers=3 ! '
+            f'videorate ! video/x-raw,framerate=1/1 ! '
+            f'videoconvert ! pngenc ! filesink location="{output_path}"'
+        )
+        pipeline.set_state(Gst.State.PLAYING)
+        gst_bus = pipeline.get_bus()
+        msg = gst_bus.timed_pop_filtered(
+            10 * Gst.SECOND,
+            Gst.MessageType.EOS | Gst.MessageType.ERROR,
+        )
+        if msg and msg.type == Gst.MessageType.ERROR:
+            err, dbg = msg.parse_error()
+            print(f"[portal-screenshot] GStreamer error: {err.message}",
+                  file=sys.stderr)
+            pipeline.set_state(Gst.State.NULL)
+            return 1
+        pipeline.set_state(Gst.State.NULL)
+    except Exception as e:
+        print(f"[portal-screenshot] GStreamer failed: {e}", file=sys.stderr)
+        # Fallback: try gst-launch-1.0 CLI
+        try:
+            subprocess.run([
+                "gst-launch-1.0",
+                f"pipewiresrc", f"path={node_id}", "num-buffers=3", "!",
+                "videorate", "!", "video/x-raw,framerate=1/1", "!",
+                "videoconvert", "!", "pngenc", "!",
+                "filesink", f"location={output_path}",
+            ], timeout=10, check=True, capture_output=True)
+        except Exception as e2:
+            print(f"[portal-screenshot] gst-launch fallback failed: {e2}",
+                  file=sys.stderr)
+            return 1
+
+    if not os.path.exists(output_path):
+        print("[portal-screenshot] output file not created", file=sys.stderr)
+        return 1
+
+    # Crop if coordinates provided
+    if crop:
+        x, y, w, h = crop
+        try:
+            from gi.repository import GdkPixbuf
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file(output_path)
+            pw, ph = pixbuf.get_width(), pixbuf.get_height()
+            # Clamp to image bounds
+            cx = min(x, pw - 1)
+            cy = min(y, ph - 1)
+            cw = min(w, pw - cx)
+            ch = min(h, ph - cy)
+            cropped = GdkPixbuf.Pixbuf.new(
+                GdkPixbuf.Colorspace.RGB, pixbuf.get_has_alpha(), 8, cw, ch)
+            pixbuf.copy_area(cx, cy, cw, ch, cropped, 0, 0)
+            cropped.savev(output_path, "png", [], [])
+        except ImportError:
+            # Fall back to ImageMagick convert
+            try:
+                subprocess.run([
+                    "convert", output_path,
+                    "-crop", f"{w}x{h}+{x}+{y}", "+repage",
+                    output_path,
+                ], timeout=5, check=True, capture_output=True)
+            except Exception:
+                pass  # Return uncropped screenshot rather than failing
+
+    # Close the portal session
+    if state["session"]:
+        try:
+            bus.call_sync(
+                "org.freedesktop.portal.Desktop",
+                state["session"],
+                "org.freedesktop.portal.Session",
+                "Close",
+                None,
+                None,
+                Gio.DBusCallFlags.NONE,
+                1000,
+                None,
+            )
+        except Exception:
+            pass
+
+    print("[portal-screenshot] success", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    # Don't hang on SIGALRM
+    signal.signal(signal.SIGALRM, lambda *_: sys.exit(1))
+    signal.alarm(TIMEOUT_SECS + 5)
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds XDG ScreenCast portal screenshot support for GNOME Wayland (46+) with PipeWire restore token persistence. This eliminates repeated permission dialogs when taking screenshots on GNOME Wayland by caching and reusing the portal permission token across invocations.

## Key Changes

- **New script**: `scripts/gnome-portal-screenshot.py` — A standalone Python script that:
  - Uses the XDG ScreenCast portal API to request screen capture permission
  - Captures frames via PipeWire using GStreamer
  - Persists the restore token to `~/.config/Claude/pipewire-restore-token`
  - Supports optional region cropping via command-line arguments
  - Includes fallback to `gst-launch-1.0` CLI if GStreamer bindings fail
  - Gracefully handles missing dependencies (returns exit code 2)

- **Integration into patch**: `patches/fix_computer_use_linux.py`
  - Embeds the portal screenshot script as a minified string constant
  - Adds `_ensurePortalScript()` to write the script to disk on first use
  - Adds `_hasPortalDeps()` to check for required dependencies (`python3`, `gst-launch-1.0`)
  - Inserts portal+PipeWire as the preferred screenshot method for GNOME Wayland (before gdbus fallback)
  - Adds diagnostic logging to report whether a restore token is cached

- **Documentation updates**:
  - Updates README.md and CLAUDE.md to reflect portal+PipeWire as the preferred GNOME Wayland method
  - Updates PKGBUILD.template optional dependencies to include `python-gobject` and `gstreamer`

## Implementation Details

- **Portal flow**: CreateSession → SelectSources (with restore token if available) → Start → capture via PipeWire
- **Token persistence**: First invocation shows the permission dialog; subsequent invocations reuse the saved token and capture silently
- **Timeout handling**: 15-second timeout for portal operations with a 20-second alarm guard to prevent hangs
- **Graceful degradation**: Falls back to gdbus method if portal script is unavailable or dependencies are missing
- **Cropping support**: Uses GdkPixbuf if available, falls back to ImageMagick `convert` command

https://claude.ai/code/session_01S4ixZ887DSQ7biandR833K