### PR TITLE
Fix unquoted TARBALL variable in build-patched-tarball.sh

### DIFF
--- a/scripts/build-patched-tarball.sh
+++ b/scripts/build-patched-tarball.sh
@@ -375,6 +375,6 @@ echo "  SHA256:   $SHA256"
 # Write metadata file for CI
 cat > "$OUTPUT_DIR/build-info.txt" << EOF
 VERSION=$VERSION
-TARBALL=$TARBALL_FILE
+TARBALL="$TARBALL_FILE"
 SHA256=$SHA256
 EOF


### PR DESCRIPTION
Fixes #42

## Problem

`build-info.txt` is written with an unquoted variable:

```bash
TARBALL=$TARBALL_FILE
```

On build paths containing spaces, the value gets split — `build-rpm.sh` then fails to read the filename correctly.

## Fix

```bash
TARBALL="$TARBALL_FILE"
```

One-character change, no functional impact on paths without spaces.