### PR TITLE
Fix opaque frame behind Quick Entry with distinct Wayland app_id so shell-extension users can blacklist it (closes #39)

### DIFF
--- a/patches/fix_quick_entry_app_id.nim
+++ b/patches/fix_quick_entry_app_id.nim
@@ -1,0 +1,227 @@
+# @patch-target: app.asar.contents/.vite/build/index.js
+# @patch-type: nim
+#
+# Give the Quick Entry BrowserWindow its own Wayland app_id (and X11
+# WM_CLASS) so it can be addressed independently from the main Claude
+# window - primarily so GNOME shell-extension users can blacklist the
+# Quick Entry pill without also disabling effects on the main chat
+# window.
+#
+# ============================================================================
+# Problem
+# ============================================================================
+# The Quick Entry is a transparent, frameless second BrowserWindow
+# hardcoded to 606 x 470 px so a small pill can grow vertically for
+# multi-line input. At rest most of that area is transparent, so only
+# the renderer-drawn pill should be visible.
+#
+# GNOME shell extensions that add uniform rounded corners + drop
+# shadow (Rounded Window Corners Reborn, Unite, ...) decorate every
+# window by attaching a child actor filled with a solid opaque
+# background and a CSS `box-shadow`, clipped to a rounded rectangle
+# the size of the window. On opaque windows the app's own pixels
+# cover that decoration, so only the soft shadow spilling past the
+# edges is visible. On the transparent Quick Entry the decoration
+# shows through the transparent area: the user sees a large opaque
+# rectangle with a shadow, and the real pill floating in its
+# top-left corner (issue #39).
+#
+# The extensions let users exclude windows via a `WM_CLASS` /
+# Wayland `app_id` blacklist, but Electron assigns app_id
+# process-wide, so the main Claude window and Quick Entry share
+# `com.anthropic.claude-desktop` and can only be blacklisted
+# together. The user loses rounded corners on the main window just
+# to hide the opaque rectangle behind Quick Entry, or keeps the
+# rectangle.
+#
+# ============================================================================
+# Why other "quieter" fixes don't work on Wayland
+# ============================================================================
+# Several obvious workarounds have been tried and rejected:
+#
+#  - **Setting `type: "toolbar"` (or "notification", "dock", ...) on the
+#    BrowserWindow options.** On X11 this sets
+#    `_NET_WM_WINDOW_TYPE_TOOLBAR`, which Mutter exposes as
+#    `Meta.WindowType.TOOLBAR`, which the extension skips because it
+#    only decorates NORMAL/DIALOG/MODAL_DIALOG windows. On native
+#    Wayland, however, Chromium/Ozone does not translate Electron's
+#    `type` option into anything visible to Mutter: the xdg_toplevel
+#    is created like a normal window and Mutter maps it to
+#    `Meta.WindowType.NORMAL`. Verified by running the extension in
+#    debug mode and observing `win.windowType = 0` (= NORMAL) on the
+#    Quick Entry.
+#
+#  - **Shrinking the BrowserWindow to exactly the card size** so there
+#    is no empty area for the extension to paint over. Works
+#    cosmetically, but breaks multi-line input (user would have to
+#    scroll inside the textarea) and needs CSS/JS patches to keep the
+#    card's first line aligned with the logo when the textarea grows.
+#    Has a visible 8 px content shift at the 40 -> 56 px textarea
+#    transition that cannot be eliminated without further CSS hacks.
+#    Also does nothing to stop the extension from (uselessly)
+#    re-painting on every resize.
+#
+#  - **Calling `xdotool set_window --class`** after creation. Works
+#    only on X11/XWayland. Native Wayland has no protocol for a client
+#    to change another window's app_id.
+#
+#  - **Spawning Quick Entry as a separate Electron process with a
+#    different binary symlink name.** Was considered. Much more
+#    invasive (two processes, IPC, spawn latency) and only needed if
+#    the CHROME_DESKTOP trick below doesn't work - which turned out
+#    not to be the case.
+#
+# ============================================================================
+# What actually controls the Wayland app_id
+# ============================================================================
+# Chromium's Ozone-Wayland backend calls `xdg_toplevel.set_app_id`
+# when a BrowserWindow is constructed. The value it sends comes from
+# `GetXdgAppId()` in `chrome/browser/shell_integration_linux.cc`:
+#
+#     std::optional<std::string> GetXdgAppId() {
+#       auto name = GetDesktopName();  // reads $CHROME_DESKTOP
+#       if (!name) return {};
+#       if (name->ends_with(".desktop"))
+#         name->resize(size(*name) - 8);
+#       return *name;
+#     }
+#
+# So the app_id is the basename of whatever the `CHROME_DESKTOP`
+# environment variable points at, with any `.desktop` suffix stripped.
+# The launcher script sets `CHROME_DESKTOP=com.anthropic.claude-desktop.desktop`
+# at startup, so every BrowserWindow gets
+# `app_id = com.anthropic.claude-desktop` by default.
+#
+# Critically, Chromium re-reads `CHROME_DESKTOP` at each new
+# `xdg_toplevel.set_app_id` call, not once at process start. If we
+# change the env var BEFORE `new BrowserWindow(...)` runs, the
+# resulting window gets whatever id we set. This was verified
+# empirically: with the swap below in place, the extension's debug
+# log reports
+#     wmClass = com.anthropic.claude-quick-entry
+# for the Quick Entry window, while the main window keeps
+#     wmClass = com.anthropic.claude-desktop
+#
+# Electron's `app.setDesktopName()` is a thin wrapper around setting
+# the same env var from the JS side, so we call both for safety.
+#
+# ============================================================================
+# Fix
+# ============================================================================
+# Two small injections in the Quick Entry setup chain:
+#
+#  1. BEFORE the `new wA.BrowserWindow(...)` that creates `Po`:
+#     set CHROME_DESKTOP to "com.anthropic.claude-quick-entry.desktop"
+#     (and call app.setDesktopName).
+#
+#  2. ON the window's first "ready-to-show" event: reset CHROME_DESKTOP
+#     (and app.setDesktopName) back to
+#     "com.anthropic.claude-desktop.desktop", so any later
+#     BrowserWindow the app creates (dialogs, printing preview, etc.)
+#     gets the original app_id again.
+#
+# We use `.once("ready-to-show")` rather than a blind setTimeout
+# because ready-to-show guarantees Chromium has dispatched
+# `xdg_toplevel.set_app_id` to the compositor. Resetting any earlier
+# risks a race where the protocol message goes out with the reset
+# value.
+#
+# Quick Entry itself is only constructed once per session (upstream
+# guards with `Po || (Po = new ...)`), so it retains its custom app_id
+# for its whole lifetime even though the env var is restored.
+#
+# ============================================================================
+# How users act on this
+# ============================================================================
+# With the patch in place, GNOME shell-extension users who see the
+# opaque-rectangle symptom can simply add
+#     com.anthropic.claude-quick-entry
+# to the extension's blacklist (Rounded Window Corners Reborn,
+# Unite, Blur My Shell, ...). The Quick Entry then renders with no
+# compositor-side shadow or rounded-corner paint, so the transparent
+# empty area around the card is actually transparent. The main Claude
+# window is unaffected because its app_id is unchanged.
+#
+# Users who don't run such an extension see no difference at all.
+#
+# ============================================================================
+# Pattern anchors
+# ============================================================================
+# Anchor 1: `([\w$]+)||(([\w$]+)=new ([\w$]+).BrowserWindow({titleBarStyle:"hidden"`
+#           The `||` short-circuit plus the exact options prefix is
+#           only present for the Quick Entry constructor in the bundle.
+#           Minifier renames force us to capture the winVar and
+#           electronVar; nim-regex lacks backreferences so we verify
+#           the two identifier captures agree in the callback.
+#
+# Anchor 2: the `Po.loadFile(.../quick-window.html)` call. It's the
+#           cleanest statement in the setup comma-chain to append our
+#           `.once("ready-to-show")` reset to.
+
+import std/[os, strutils]
+import regex
+
+const MAIN_APP_ID = "com.anthropic.claude-desktop"
+const QE_APP_ID = "com.anthropic.claude-quick-entry"
+
+proc apply*(input: string): string =
+  result = input
+
+  # -----------------------------------------------------------------
+  # 1. Pre-create: swap CHROME_DESKTOP to the Quick Entry id.
+  # -----------------------------------------------------------------
+  let preCreatePattern = re2(r"""([\w$]+)\|\|\(([\w$]+)=new ([\w$]+)\.BrowserWindow\(\{titleBarStyle:"hidden"""")
+  var preCount = 0
+  result = result.replace(preCreatePattern, proc(m: RegexMatch2, s: string): string =
+    let w1 = s[m.group(0)]
+    let w2 = s[m.group(1)]
+    let electronVar = s[m.group(2)]
+    if w1 != w2:
+      # The short-circuit target and assignment LHS must be the same
+      # var; bail out by reconstructing the original match.
+      return w1 & "||(" & w2 & "=new " & electronVar & ".BrowserWindow({titleBarStyle:\"hidden\""
+    inc preCount
+    w1 & "||(" &
+      "process.env.CHROME_DESKTOP=\"" & QE_APP_ID & ".desktop\"," &
+      "(typeof " & electronVar & ".app.setDesktopName===\"function\"&&" & electronVar & ".app.setDesktopName(\"" & QE_APP_ID & ".desktop\"))," &
+      w2 & "=new " & electronVar & ".BrowserWindow({titleBarStyle:\"hidden\""
+  )
+  if preCount != 1:
+    echo "  [FAIL] Expected 1 Quick Entry pre-create pattern, got " & $preCount
+    quit(1)
+  echo "  [OK] CHROME_DESKTOP swap to " & QE_APP_ID & " inserted before BrowserWindow: " & $preCount & " match(es)"
+
+  # -----------------------------------------------------------------
+  # 2. Post-create: schedule reset on the window's ready-to-show.
+  # -----------------------------------------------------------------
+  let loadFilePattern = re2(r"""(([\w$]+)\.loadFile\(([\w$]+)\.join\(([\w$]+)\.app\.getAppPath\(\),"\.vite/renderer/quick_window/quick-window\.html"\)\))""")
+  var postCount = 0
+  result = result.replace(loadFilePattern, proc(m: RegexMatch2, s: string): string =
+    inc postCount
+    let original = s[m.group(0)]
+    let winVar = s[m.group(1)]
+    let electronVar = s[m.group(3)]
+    original & "," &
+      winVar & ".once(\"ready-to-show\",()=>{" &
+        "try{" &
+          "process.env.CHROME_DESKTOP=\"" & MAIN_APP_ID & ".desktop\";" &
+          "typeof " & electronVar & ".app.setDesktopName===\"function\"&&" & electronVar & ".app.setDesktopName(\"" & MAIN_APP_ID & ".desktop\");" &
+        "}catch(__qeAppIdResetErr){}" &
+      "})"
+  )
+  if postCount != 1:
+    echo "  [FAIL] Expected 1 Quick Entry loadFile pattern, got " & $postCount
+    quit(1)
+  echo "  [OK] CHROME_DESKTOP reset to " & MAIN_APP_ID & " scheduled on ready-to-show: " & $postCount & " match(es)"
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: fix_quick_entry_app_id <file>"
+    quit(1)
+  let filePath = paramStr(1)
+  echo "=== Patch: fix_quick_entry_app_id ==="
+  echo "  Target: " & filePath
+  let input = readFile(filePath)
+  let output = apply(input)
+  writeFile(filePath, output)
+  echo "  [PASS] Quick Entry app_id swap patched"


### PR DESCRIPTION
Closes #39.

## Background: why the Quick Entry window is "too big"

The Quick Entry BrowserWindow is hardcoded to 606 x 470 CSS pixels. At
rest only a ~556 x 56 rounded pill is actually drawn in the top area;
the rest is transparent empty space. That extra height is not a bug,
it's headroom for multi-line input: the textarea inside the pill grows
as the user types Shift+Enter newlines, and the renderer's resize logic
scales the visible card within that 470 px envelope. The window itself
can't resize on Wayland (see alternatives below), so upstream picks one
size large enough to hold typical multi-line input and relies on the
rest being transparent.

The window being transparent is how upstream hides the empty area. It
works on a plain desktop, and it works on the macOS build. The issue
only shows up when a compositor-level decoration gets drawn into that
transparent area.

## What was actually wrong

In the issue thread I concluded the opaque frame/rectangle looked like a Mutter 49
regression, because disabling the GPU, XWayland, fractional scaling etc. all still
showed it. I was wrong. It is not a Mutter bug and it reproduces on older GNOME
versions too. It is caused by a GNOME shell extension: **[Rounded Window Corners Reborn](https://github.com/flexagoon/rounded-window-corners)**
(or Unite, or any extension in that family).

These extensions give every window uniform rounded corners + drop shadow by
attaching a child actor to every `MetaWindowActor`. That actor is filled with a
solid opaque background colour and a CSS `box-shadow`, then clipped to a
rounded rectangle the size of the window.

- On **opaque** windows, the app's own pixels cover the decoration; only the
  soft shadow spilling past the edges is visible. Correct behaviour.
- On **transparent** windows like the Quick Entry (606 x 470 surface with only
  a ~556 x 56 pill actually drawn), the extension's decoration shows straight
  through the transparent pixels. The user sees the big opaque rectangle plus
  its shadow, with the real pill floating in the top-left corner - this is
  the screenshot originally posted in #39:

<img width="879" height="652" alt="Quick Entry opaque frame symptom" src="https://github.com/user-attachments/assets/70ab23bb-58a1-4716-95d3-bcfd4a75cf14" />

This is easy to confirm: `gnome-extensions disable rounded-window-corners@fxgn`
makes the rectangle vanish instantly; re-enabling brings it back. None of the
flags I tried earlier (`CLAUDE_DISABLE_GPU=full`, `CLAUDE_USE_XWAYLAND=1`,
`--disable-features=WaylandWindowDecorations`, fractional scaling off) touched
the extension, which is why the symptom persisted through all of them and
looked like a compositor issue.

So the opaque frame is not a bug we can fix in Mutter or in the renderer. It is
the extension doing exactly what it's supposed to do, on a window type it was
never really designed for.

## Why we can't just "not decorate Quick Entry"

Extensions in this family already let users exclude windows by `WM_CLASS` /
Wayland `app_id`. The problem is that both the main Claude window and the
Quick Entry share `com.anthropic.claude-desktop` today, because Electron
assigns app_id process-wide. Blacklisting catches both windows, so the user
either loses rounded corners on the main chat too, or keeps the opaque
rectangle behind Quick Entry. No useful middle option.

Other workarounds I rejected before landing on this:

- `type: "toolbar"` (or `notification`/`dock`) in the `BrowserWindow` options:
  the extension skips any `windowType !== NORMAL/DIALOG/MODAL_DIALOG`, but on
  native Wayland Chromium/Ozone does not translate Electron's `type` into
  anything Mutter sees. The `xdg_toplevel` is created like a normal window and
  `Meta.WindowType` stays at `NORMAL`. Confirmed via the extension's debug log.
- Shrinking the Quick Entry `BrowserWindow` down to the pill size and regrowing
  it on textarea input: cosmetic fix only, requires a stack of CSS/JS patches
  to keep the logo and first line aligned while the textarea grows, and on
  native Wayland Mutter ignores the resulting `setContentSize`/`setBounds`
  calls (`xdg_toplevel` has no protocol for a client to move itself), so the
  window ends up misaligned. It also does nothing to stop the extension from
  re-painting on every resize.
- `xdotool set_window --class`: X11/XWayland only. Native Wayland has no
  protocol for a client to change another window's app_id either.
- A separate Electron process for Quick Entry (symlink trick): possible but
  invasive (two processes, IPC, spawn latency) and unnecessary once the
  env-var trick below works.

## What this PR does

Chromium's Ozone-Wayland calls `xdg_toplevel.set_app_id` on each new
`BrowserWindow`, and it reads the value from `$CHROME_DESKTOP` every time,
not just at process start. So we can give the Quick Entry window a distinct
app_id by:

1. Swapping `process.env.CHROME_DESKTOP` (and calling
   `app.setDesktopName()`) to `com.anthropic.claude-quick-entry.desktop`
   **immediately before** the Quick Entry `new BrowserWindow(...)` call.
2. Swapping it back to `com.anthropic.claude-desktop.desktop` on the
   window's first `ready-to-show` event (rather than a blind
   `setTimeout`, so we know Chromium has already dispatched
   `set_app_id` to the compositor before we revert). Any later
   `BrowserWindow` the process creates (dialogs etc.) then gets the
   original app_id back.

The Quick Entry `BrowserWindow` is only constructed once per session -
upstream guards the `new` with `Po || (Po = new ...)`, so subsequent
opens reuse the same instance - which means it keeps its custom app_id
for the whole session even though the env var is reset right after
creation.

Verified with the Rounded Window Corners Reborn extension's own debug log:

```
[Rounded Window Corners] Check Type of window:Claude
  wmClass=com.anthropic.claude-quick-entry
```

Main Claude window still reports `wmClass=com.anthropic.claude-desktop`.
With `com.anthropic.claude-quick-entry` added to the extension's blacklist,
the opaque rectangle is gone and the main window keeps all its effects.

## User-facing impact

None, unless the user runs one of the affected shell extensions. In that case
they can now add `com.anthropic.claude-quick-entry` to the extension's
blacklist. For everyone else the patch is invisible.

## Implementation

One new Nim patch: `patches/fix_quick_entry_app_id.nim`. Two regex-anchored
injections into the Quick Entry setup chain, no other runtime behaviour
changes. The patch header has the same problem description + rationale
inline for future maintainers.

Tested on:

- Fedora Linux 43, GNOME Shell 49.5 / Mutter 49.5, Wayland
- Electron 41.2.1, Chromium 146.0.7680.188
- With and without the Rounded Window Corners Reborn extension enabled