### PR TITLE
Reduce Quick Entry opening timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-04-19 — Reduce Quick Entry opening timeouts
+
+### Changed
+- **`fix_quick_entry_ready_wayland`**: Wayland `ready-to-show` fallback timeout 200ms → 100ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
+- **`fix_quick_entry_cli_toggle`**: First-instance argv schedule 500ms → 250ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
+- **`fix_quick_entry_position`**: Cursor detection subprocess timeouts (xdotool, hyprctl) 200ms → 100ms each ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
+
+---
+
 ## 2026-04-19 — Add missing patches to README table
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to claude-desktop-bin AUR package will be documented in this
 
 ### Changed
 - **`fix_quick_entry_ready_wayland`**: Wayland `ready-to-show` fallback timeout 200ms → 100ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
-- **`fix_quick_entry_cli_toggle`**: First-instance argv schedule 500ms → 250ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
-- **`fix_quick_entry_position`**: Cursor detection subprocess timeouts (xdotool, hyprctl) 200ms → 100ms each ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
+- **`fix_quick_entry_cli_toggle`**: First-instance argv schedule 500ms → 250ms, debounce guard 900ms → 500ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
+- **`fix_quick_entry_position`**: Cursor detection subprocess timeouts (xdotool, hyprctl) 200ms → 100ms each, xdotool windowactivate timeout 500ms → 300ms ([#47](https://github.com/patrickjaja/claude-desktop-bin/issues/47))
 
 ---
 

--- a/patches/fix_quick_entry_cli_toggle.nim
+++ b/patches/fix_quick_entry_cli_toggle.nim
@@ -39,7 +39,7 @@ proc apply*(input: string): string =
         let body = arrow[len("()=>{") ..< arrow.len - 1]
 
         # A: register with assignment to globalThis AND a debounce guard
-        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<900)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
+        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<500)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
         let assign = "globalThis." & HANDLER_GLOBAL & "=" & arrowWrapped
 
         # C: schedule first-instance check

--- a/patches/fix_quick_entry_cli_toggle.nim
+++ b/patches/fix_quick_entry_cli_toggle.nim
@@ -52,7 +52,7 @@ proc apply*(input: string): string =
           ")globalThis." &
           HANDLER_GLOBAL &
           "()}catch(e){}" &
-          "},500)"
+          "},250)"
 
         resultStr &= regFn & "(" & enumVar & ".QUICK_ENTRY," & assign & ")" & firstInstance
         lastEnd = bounds.b + 1

--- a/patches/fix_quick_entry_position.nim
+++ b/patches/fix_quick_entry_position.nim
@@ -13,14 +13,14 @@ proc cursorIife(electronVar: string): string =
   "const cp=require(\"child_process\");" &
   "try{" &
   "const r=cp.execFileSync(\"xdotool\",[\"getmouselocation\",\"--shell\"]," &
-  "{timeout:200,encoding:\"utf-8\"});" &
+  "{timeout:100,encoding:\"utf-8\"});" &
   "const x=parseInt(r.match(/X=(\\d+)/)?.[1]);" &
   "const y=parseInt(r.match(/Y=(\\d+)/)?.[1]);" &
   "if(!isNaN(x)&&!isNaN(y)){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using xdotool\")}return{x,y}}" &
   "}catch(e){}" &
   "try{" &
   "const r=cp.execFileSync(\"hyprctl\",[\"cursorpos\"]," &
-  "{timeout:200,encoding:\"utf-8\"});" &
+  "{timeout:100,encoding:\"utf-8\"});" &
   "const m=r.match(/(\\d+),\\s*(\\d+)/);" &
   "if(m){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using hyprctl\")}return{x:parseInt(m[1]),y:parseInt(m[2])}}" &
   "}catch(e){}" &

--- a/patches/fix_quick_entry_position.nim
+++ b/patches/fix_quick_entry_position.nim
@@ -110,7 +110,7 @@ proc apply*(input: string): string =
       "const cp=require(\"child_process\");" &
       "const wid=" & w & ".getNativeWindowHandle().readUInt32LE(0);" &
       "cp.execFile(\"xdotool\",[\"windowactivate\",\"--sync\",String(wid)]," &
-      "{timeout:500},(e)=>{if(!" & w & ".isDestroyed()){_ef()}});" &
+      "{timeout:300},(e)=>{if(!" & w & ".isDestroyed()){_ef()}});" &
       "}catch(e){_ef()}};" &
       "const _ff=()=>{_ef();if(_isX11){_xf()}};" &
       w & ".setBounds(_b);" &

--- a/patches/fix_quick_entry_ready_wayland.nim
+++ b/patches/fix_quick_entry_ready_wayland.nim
@@ -7,7 +7,7 @@
 # BrowserWindows on native Wayland. The Quick Entry window (Mlr function)
 # awaits this event indefinitely, causing the overlay to never appear.
 #
-# This patch adds a 200ms timeout to the ready-to-show wait so the Quick
+# This patch adds a 100ms timeout to the ready-to-show wait so the Quick
 # Entry window proceeds to show even if the event never fires.
 
 import std/[os, strutils, options]
@@ -25,9 +25,9 @@ proc apply*(input: string): string =
     let match = m.get
     let flagVar = match.captures[0]
     let promiseVar = match.captures[1]
-    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,200))])"""
+    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,100))])"""
     result = input[0 ..< match.matchBounds.a] & newStr & input[match.matchBounds.b + 1 .. ^1]
-    echo "  [OK] ready-to-show timeout (200ms) added (vars: " & flagVar & ", " & promiseVar & ")"
+    echo "  [OK] ready-to-show timeout (100ms) added (vars: " & flagVar & ", " & promiseVar & ")"
   else:
     echo "  [FAIL] ready-to-show wait pattern not found"
     quit(1)


### PR DESCRIPTION
## Summary

Reduces three Quick Entry timeout values based on analysis of upstream v1.3109.0 code and timing measurements from #47:

- **`fix_quick_entry_ready_wayland`**: 200ms → 100ms — Wayland `ready-to-show` fallback (this timeout is always hit on Wayland since the event never fires for transparent frameless windows)
- **`fix_quick_entry_cli_toggle`**: 500ms → 250ms — first-instance `--toggle-quick-entry` argv check delay at cold start
- **`fix_quick_entry_position`**: 200ms → 100ms — xdotool/hyprctl cursor detection subprocess timeouts (both)

Upstream has **zero `setTimeout` calls** in the Quick Entry show path — all timeouts are Linux-specific patches. Instrumentation shows handler→`show()` takes ~73ms on first open and ~1ms on subsequent opens. The perceived delay is the Wayland compositor window mapping round-trip, not the JS timeouts.

Closes #47

## Test plan

- [ ] Wayland (GNOME/Mutter): Quick Entry opens and receives focus
- [ ] Wayland (Hyprland): Quick Entry opens on correct monitor
- [ ] X11: Quick Entry opens, xdotool focus works
- [ ] Cold start with `claude-desktop --toggle-quick-entry` triggers Quick Entry
- [ ] Rapid double-press of shortcut doesn't cause show/hide flicker