### PR TITLE
perf(quick-entry): Unix socket trigger + Wayland retry gate (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-04-19 - Quick Entry: socket trigger + Wayland retry gate + timeout reductions (#47)
+
+### Added
+- **`claude-desktop-toggle`**: New helper script installed to `/usr/bin` by all package
+  formats (AUR, RPM, DEB, AppImage, NixOS). Connects to a Unix domain socket the app
+  creates on startup at `/run/user/<uid>/claude-desktop-qe.sock`, toggling Quick Entry
+  in ~5-25 ms instead of ~300 ms. Uses `socat` (~2 ms) if available, falls back to
+  `python3` (~25 ms, always present on Linux), then falls back to
+  `claude-desktop --toggle-quick-entry` if the app is not running.
+  **GNOME users:** run `claude-desktop --install-gnome-hotkey` once to update the stored
+  shortcut command. KDE/Sway/Hyprland/X11 users who configured their shortcut manually
+  should update it to `claude-desktop-toggle`.
+
+### Performance
+- **`fix_quick_entry_cli_toggle`** (sub-patch D): Unix domain socket server injected on
+  startup. Any connection directly calls the Quick Entry toggle handler, bypassing the
+  Electron process-spawn + `second-instance` IPC path entirely (~300 ms overhead per
+  keypress). As a side effect, the GNOME double-fire regression from issue #38 is
+  eliminated: `second-instance` is never triggered while the app is running, so there is
+  nothing left to double-fire.
+- **`fix_quick_entry_cli_toggle`**: Debounce window reduced from 900 ms to 100 ms. The
+  guard catches GNOME's duplicate `second-instance` delivery (fires within 1-5 ms,
+  issue #38). 900 ms blocked normal rapid open/close sequences; 100 ms is still 20x the
+  double-fire window.
+- **`fix_quick_entry_position`**: Position+focus retries (50/150/300 ms) gated to X11
+  only (`if(_isX11)`). On Wayland the compositor never repositions windows after `show()`,
+  so the retries were pointless and caused visible jitter on every open. X11 behaviour
+  is unchanged.
+- **`fix_quick_entry_ready_wayland`**: `ready-to-show` timeout reduced from 200 ms to
+  100 ms. Chromium first-paint on Wayland is typically 30-50 ms; 100 ms still provides
+  comfortable headroom.
+- **`fix_quick_entry_cli_toggle`**: First-instance trigger delay reduced from 500 ms to
+  250 ms, saving 250 ms on cold-start CLI opens (e.g. hotkey with app not yet running).
+- **`fix_quick_entry_position`**: `execFileSync` timeouts for `xdotool` and `hyprctl`
+  reduced from 200 ms to 100 ms. Both commands respond in under 20 ms; 100 ms is still
+  5x headroom before falling back to the Electron API.
+
+---
+
 ## 2026-04-19 — Add missing patches to README table
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
-## 2026-04-19 - Quick Entry: socket trigger + Wayland retry gate + timeout reductions (#47)
+## 2026-04-19 - Quick Entry: socket trigger + Wayland retry gate (#47)
 
 ### Added
 - **`claude-desktop-toggle`**: New helper script installed to `/usr/bin` by all package
@@ -22,22 +22,10 @@ All notable changes to claude-desktop-bin AUR package will be documented in this
   keypress). As a side effect, the GNOME double-fire regression from issue #38 is
   eliminated: `second-instance` is never triggered while the app is running, so there is
   nothing left to double-fire.
-- **`fix_quick_entry_cli_toggle`**: Debounce window reduced from 900 ms to 100 ms. The
-  guard catches GNOME's duplicate `second-instance` delivery (fires within 1-5 ms,
-  issue #38). 900 ms blocked normal rapid open/close sequences; 100 ms is still 20x the
-  double-fire window.
 - **`fix_quick_entry_position`**: Position+focus retries (50/150/300 ms) gated to X11
   only (`if(_isX11)`). On Wayland the compositor never repositions windows after `show()`,
   so the retries were pointless and caused visible jitter on every open. X11 behaviour
   is unchanged.
-- **`fix_quick_entry_ready_wayland`**: `ready-to-show` timeout reduced from 200 ms to
-  100 ms. Chromium first-paint on Wayland is typically 30-50 ms; 100 ms still provides
-  comfortable headroom.
-- **`fix_quick_entry_cli_toggle`**: First-instance trigger delay reduced from 500 ms to
-  250 ms, saving 250 ms on cold-start CLI opens (e.g. hotkey with app not yet running).
-- **`fix_quick_entry_position`**: `execFileSync` timeouts for `xdotool` and `hyprctl`
-  reduced from 200 ms to 100 ms. Both commands respond in under 20 ms; 100 ms is still
-  5x headroom before falling back to the Electron API.
 
 ---
 

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -59,6 +59,9 @@ package() {
     # Install launcher script (Wayland/X11 detection, env setup, lock cleanup)
     install -Dm755 "$srcdir/launcher/claude-desktop" "$pkgdir/usr/bin/claude-desktop"
 
+    # Install Quick Entry toggle helper (fast hotkey via Unix socket, ~5-25 ms vs ~300 ms)
+    install -Dm755 "$srcdir/launcher/claude-desktop-toggle" "$pkgdir/usr/bin/claude-desktop-toggle"
+
     # Install desktop entry.
     # Filename must match APP_ID in the launcher (com.anthropic.claude-desktop)
     # so xdg-desktop-portal can resolve our systemd-scope / cgroup identity.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ sudo pacman -S --needed ydotool xdotool spectacle imagemagick
 sudo pacman -S --needed ydotool xdotool glib2 gnome-screenshot imagemagick python-gobject gst-plugin-pipewire
 # GNOME Wayland: enable Quick Entry hotkey (one-time, after install):
 # claude-desktop --install-gnome-hotkey
-# Optional: socat (cowork socket health checks, has fallback)
+# Set your hotkey command to: claude-desktop-toggle  (fast socket trigger, ~5-25 ms)
+# Optional: socat (faster socket client, ~2 ms -- claude-desktop-toggle uses python3 fallback)
 # sudo pacman -S --needed socat
 ```
 On Wayland, the `ydotoold` daemon must be running — see [ydotool setup](#ydotool-setup-wayland).
@@ -61,7 +62,8 @@ sudo apt install ydotool xdotool kde-spectacle imagemagick
 sudo apt install ydotool xdotool libglib2.0-bin gnome-screenshot imagemagick python3-gi gstreamer1.0-pipewire
 # GNOME Wayland: enable Quick Entry hotkey (one-time, after install):
 # claude-desktop --install-gnome-hotkey
-# Optional: socat (cowork socket health checks, has fallback)
+# Set your hotkey command to: claude-desktop-toggle  (fast socket trigger, ~5-25 ms)
+# Optional: socat (faster socket client, ~2 ms -- claude-desktop-toggle uses python3 fallback)
 # sudo apt install socat
 ```
 
@@ -100,7 +102,8 @@ sudo dnf install ydotool xdotool spectacle ImageMagick
 sudo dnf install ydotool xdotool glib2 gnome-screenshot ImageMagick python3-gobject gstreamer1-plugin-pipewire
 # GNOME Wayland: enable Quick Entry hotkey (one-time, after install):
 # claude-desktop --install-gnome-hotkey
-# Optional: socat (cowork socket health checks, has fallback)
+# Set your hotkey command to: claude-desktop-toggle  (fast socket trigger, ~5-25 ms)
+# Optional: socat (faster socket client, ~2 ms -- claude-desktop-toggle uses python3 fallback)
 # sudo dnf install socat
 ```
 On Wayland, the `ydotoold` daemon must be running — see [ydotool setup](#ydotool-setup-wayland).
@@ -142,7 +145,8 @@ claude-desktop.override {
   # glib = pkgs.glib; gnome-screenshot = pkgs.gnome-screenshot;
   # GNOME Wayland: enable Quick Entry hotkey (one-time, after install):
   # Run: claude-desktop --install-gnome-hotkey
-  # Optional: socat (cowork socket health checks, has fallback)
+  # Set your hotkey command to: claude-desktop-toggle  (fast socket trigger, ~5-25 ms)
+  # Optional: socat (faster socket client, ~2 ms -- claude-desktop-toggle uses python3 fallback)
   # socat = pkgs.socat;
 }
 ```
@@ -425,9 +429,9 @@ The package applies several patches to make Claude Desktop work on Linux. Each p
 | `fix_office_addin_linux.nim` | Extends Office Addin MCP server to include Linux | `rg -o '.{0,30}louderPenguinEnabled.{0,30}' index.js` |
 | `fix_process_argv_renderer.nim` | Injects `process.argv=[]` in renderer preload to prevent TypeError | `rg -o '.{0,30}\.argv.{0,30}' mainView.js` |
 | `fix_quick_entry_app_id.nim` | Gives Quick Entry a distinct Wayland `app_id` so shell-extension users can blacklist it independently ([#39](https://github.com/patrickjaja/claude-desktop-bin/issues/39)) | `rg -o '.{0,30}BrowserWindow.*titleBarStyle.*hidden.{0,30}' index.js` |
-| `fix_quick_entry_cli_toggle.nim` | Enables `claude-desktop --toggle-quick-entry` CLI trigger | `rg -o 'QUICK_ENTRY.{0,80}' index.js` |
-| `fix_quick_entry_position.nim` | Quick Entry opens on cursor's monitor (multi-monitor) | `rg -o 'getPrimaryDisplay.{0,50}' index.js` |
-| `fix_quick_entry_ready_wayland.nim` | Adds 200ms timeout to Quick Entry ready-to-show wait (Wayland hang fix) | `rg -o 'ready-to-show.{0,50}' index.js` |
+| `fix_quick_entry_cli_toggle.nim` | Enables `claude-desktop --toggle-quick-entry` CLI trigger + Unix socket for fast hotkey (`claude-desktop-toggle`, ~5-25 ms vs ~300 ms) | `rg -o 'QUICK_ENTRY.{0,80}' index.js` |
+| `fix_quick_entry_position.nim` | Quick Entry opens on cursor's monitor (multi-monitor); position+focus retries gated to X11 only (Wayland: no jitter) | `rg -o 'getPrimaryDisplay.{0,50}' index.js` |
+| `fix_quick_entry_ready_wayland.nim` | Adds 100ms timeout to Quick Entry ready-to-show wait (Wayland hang fix; `ready-to-show` never fires for frameless transparent windows) | `rg -o 'ready-to-show.{0,50}' index.js` |
 | `fix_quick_entry_wayland_blur_guard.nim` | Guards Quick Entry blur-to-dismiss against spurious Wayland blur events | `rg -o '.{0,30}blur.{0,30}null.{0,30}' index.js` |
 | ~~`fix_read_terminal_linux.py`~~ | **Removed in v1.2.234** — upstream now natively supports Linux | N/A |
 | `fix_startup_settings.nim` | Skips startup/login settings to avoid validation errors | `rg -o 'isStartupOnLoginEnabled.{0,50}' index.js` |
@@ -538,6 +542,18 @@ claude-desktop --install-gnome-hotkey '<Super>space'  # or any accelerator
 ```
 
 This binds the key directly via `gsettings`, bypassing the portal. See [wayland.md](wayland.md#quick-entry-hotkey-not-firing-on-gnome) for details. Run `claude-desktop --diagnose` to check hotkey status.
+
+### Hotkey command: use `claude-desktop-toggle` for fast response
+
+The default `claude-desktop --toggle-quick-entry` spawns a full Electron process per keypress (~300 ms overhead). Use `claude-desktop-toggle` instead:
+
+```bash
+claude-desktop-toggle
+```
+
+This script connects to a Unix domain socket the app creates on startup (`/run/user/<uid>/claude-desktop-qe.sock`) and toggles Quick Entry in ~5-25 ms. It falls back to `claude-desktop --toggle-quick-entry` automatically when the app is not running.
+
+Set your keyboard shortcut (GNOME, KDE, Sway, Hyprland) to run `claude-desktop-toggle` as the command.
 
 ### App identity on Wayland
 

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -125,6 +125,7 @@ mv "$APPDIR/usr/lib/claude-desktop/electron" \
 log_info "Installing launcher..."
 mkdir -p "$APPDIR/usr/bin"
 install -m755 "$WORK_DIR/tarball/launcher/claude-desktop" "$APPDIR/usr/bin/claude-desktop"
+install -m755 "$WORK_DIR/tarball/launcher/claude-desktop-toggle" "$APPDIR/usr/bin/claude-desktop-toggle"
 
 # Create AppRun (delegates to full launcher with AppImage-specific path overrides)
 log_info "Creating AppRun..."

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -11,6 +11,7 @@ override_dh_auto_install:
 	# Install launcher (full launcher with Wayland/X11 detection, GPU fallback, etc.)
 	install -d debian/claude-desktop/usr/bin
 	install -m755 launcher/claude-desktop debian/claude-desktop/usr/bin/claude-desktop
+	install -m755 launcher/claude-desktop-toggle debian/claude-desktop/usr/bin/claude-desktop-toggle
 
 	# Install desktop file (reverse-URL name must match APP_ID in the launcher)
 	install -d debian/claude-desktop/usr/share/applications

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -26,7 +26,8 @@
 # Claude Code CLI — required for Cowork, Dispatch, and Code integration
 , claude-code ? null    # auto-resolved by callPackage if in nixpkgs
 # Other optional
-, socat ? null          # cowork socket health check
+, socat ? null          # cowork socket health check; also used by claude-desktop-toggle
+, python3 ? null        # claude-desktop-toggle fallback connector (when socat is unavailable)
 , nodejs ? null         # third-party MCP servers
 # Extra PATH entries for binaries not packaged in Nix (e.g. npm global, nvm)
 , extraSessionPaths ? []
@@ -112,6 +113,33 @@ stdenvNoCC.mkDerivation {
         in "--prefix PATH : ${path}"
       ) extraSessionPaths} \
       --add-flags "$out/lib/claude-desktop/resources/app.asar"
+
+    # Install Quick Entry toggle helper (fast hotkey via Unix socket, ~5-25 ms vs ~300 ms).
+    # Hotkey command: claude-desktop-toggle
+    # Falls back to claude-desktop --toggle-quick-entry if socket unavailable.
+    cat > $out/bin/claude-desktop-toggle << 'TOGGLE_EOF'
+#!/bin/sh
+SOCK="/run/user/$(id -u)/claude-desktop-qe.sock"
+if [ -S "$SOCK" ]; then
+    if command -v socat >/dev/null 2>&1; then
+        socat /dev/null "UNIX-CLIENT:$SOCK" 2>/dev/null && exit 0
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c "
+import socket, os, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(0.5)
+s.connect(sys.argv[1])
+s.sendall(b'1')
+s.close()
+" "$SOCK" 2>/dev/null && exit 0
+    fi
+fi
+exec claude-desktop --toggle-quick-entry
+TOGGLE_EOF
+    chmod +x $out/bin/claude-desktop-toggle
+    ${lib.optionalString (socat != null) "wrapProgram $out/bin/claude-desktop-toggle --prefix PATH : ${socat}/bin"}
+    ${lib.optionalString (python3 != null) "wrapProgram $out/bin/claude-desktop-toggle --prefix PATH : ${python3}/bin"}
 
     # Install icon
     if [ -f icons/claude-desktop.png ]; then

--- a/packaging/rpm/claude-desktop-bin.spec
+++ b/packaging/rpm/claude-desktop-bin.spec
@@ -82,6 +82,7 @@ mv %{buildroot}/usr/lib/claude-desktop/electron \
 # GPU fallback, SingletonLock cleanup, cowork socket cleanup, and logging)
 mkdir -p %{buildroot}/usr/bin
 install -m755 tarball/launcher/claude-desktop %{buildroot}/usr/bin/claude-desktop
+install -m755 tarball/launcher/claude-desktop-toggle %{buildroot}/usr/bin/claude-desktop-toggle
 
 # Install desktop file.
 # Filename must match APP_ID in the launcher (com.anthropic.claude-desktop)
@@ -136,5 +137,6 @@ fi
 %files
 /usr/lib/claude-desktop/
 /usr/bin/claude-desktop
+/usr/bin/claude-desktop-toggle
 /usr/share/applications/com.anthropic.claude-desktop.desktop
 /usr/share/icons/hicolor/256x256/apps/claude-desktop.png

--- a/patches/fix_quick_entry_cli_toggle.nim
+++ b/patches/fix_quick_entry_cli_toggle.nim
@@ -5,8 +5,8 @@
 #   A - capture the Quick Entry show handler into globalThis.__ceQuickEntryShow
 #       with a 900ms debounce guard (prevents GNOME double-firing second-instance)
 #   B - prepend argv check to second-instance handler (warm-start hotkey path)
-#   C - schedule first-instance check after 250ms (cold-start: app just launched
-#       with --toggle-quick-entry; reduced from 500ms, enough for Electron init)
+#   C - schedule first-instance check after 500ms (cold-start: app just launched
+#       with --toggle-quick-entry; gives Electron enough time to initialise)
 #   D - create Unix domain socket at /run/user/<uid>/claude-desktop-qe.sock
 #       so claude-desktop-toggle can trigger Quick Entry in ~5-25ms instead of
 #       ~300ms (no Electron process spawn for every keypress)
@@ -47,14 +47,12 @@ proc apply*(input: string): string =
         let body = arrow[len("()=>{") ..< arrow.len - 1]
 
         # A: register with assignment to globalThis AND a debounce guard.
-        # 100ms debounce: safety net against any remaining edge cases.
-        # The original 900ms was added for GNOME's duplicate second-instance
-        # delivery (issue #38, double-fires within 1-5ms), but with the socket
-        # trigger (sub-patch D) the second-instance path is no longer taken when
-        # the app is running -- the socket calls __ceQuickEntryShow() directly,
-        # bypassing second-instance entirely. GNOME has nothing left to double-fire.
-        # 100ms is kept as a cheap safety net; it no longer affects normal usage.
-        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<100)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
+        # 900ms debounce: guards against GNOME's duplicate second-instance delivery
+        # (issue #38, double-fires within 1-5ms). Even though the socket trigger
+        # (sub-patch D) bypasses second-instance entirely while the app is running,
+        # the 900ms guard still protects cold-start CLI opens where second-instance
+        # is the only path (socket not yet up).
+        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<900)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
         let assign = "globalThis." & HANDLER_GLOBAL & "=" & arrowWrapped
 
         # C: schedule first-instance check
@@ -67,7 +65,7 @@ proc apply*(input: string): string =
           ")globalThis." &
           HANDLER_GLOBAL &
           "()}catch(e){}" &
-          "},250)"
+          "},500)"
 
         # D: Unix domain socket trigger -- fast hotkey path on Linux.
         #

--- a/patches/fix_quick_entry_cli_toggle.nim
+++ b/patches/fix_quick_entry_cli_toggle.nim
@@ -1,7 +1,15 @@
 # @patch-target: app.asar.contents/.vite/build/index.js
 # @patch-type: nim
 # Enable `claude-desktop --toggle-quick-entry` CLI trigger for Quick Entry.
-# Three sub-patches: A (handler capture), B (second-instance argv), C (first-instance schedule).
+# Four sub-patches (A and C share a counter slot):
+#   A - capture the Quick Entry show handler into globalThis.__ceQuickEntryShow
+#       with a 900ms debounce guard (prevents GNOME double-firing second-instance)
+#   B - prepend argv check to second-instance handler (warm-start hotkey path)
+#   C - schedule first-instance check after 250ms (cold-start: app just launched
+#       with --toggle-quick-entry; reduced from 500ms, enough for Electron init)
+#   D - create Unix domain socket at /run/user/<uid>/claude-desktop-qe.sock
+#       so claude-desktop-toggle can trigger Quick Entry in ~5-25ms instead of
+#       ~300ms (no Electron process spawn for every keypress)
 
 import std/[os, strformat, strutils]
 import regex
@@ -38,8 +46,15 @@ proc apply*(input: string): string =
 
         let body = arrow[len("()=>{") ..< arrow.len - 1]
 
-        # A: register with assignment to globalThis AND a debounce guard
-        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<900)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
+        # A: register with assignment to globalThis AND a debounce guard.
+        # 100ms debounce: safety net against any remaining edge cases.
+        # The original 900ms was added for GNOME's duplicate second-instance
+        # delivery (issue #38, double-fires within 1-5ms), but with the socket
+        # trigger (sub-patch D) the second-instance path is no longer taken when
+        # the app is running -- the socket calls __ceQuickEntryShow() directly,
+        # bypassing second-instance entirely. GNOME has nothing left to double-fire.
+        # 100ms is kept as a cheap safety net; it no longer affects normal usage.
+        let arrowWrapped = "()=>{var __t=Date.now();if(globalThis.__ceQEInvokedAt&&__t-globalThis.__ceQEInvokedAt<100)return;globalThis.__ceQEInvokedAt=__t;" & body & "}"
         let assign = "globalThis." & HANDLER_GLOBAL & "=" & arrowWrapped
 
         # C: schedule first-instance check
@@ -54,7 +69,38 @@ proc apply*(input: string): string =
           "()}catch(e){}" &
           "},250)"
 
-        resultStr &= regFn & "(" & enumVar & ".QUICK_ENTRY," & assign & ")" & firstInstance
+        # D: Unix domain socket trigger -- fast hotkey path on Linux.
+        #
+        # Problem: `claude-desktop --toggle-quick-entry` spawns a full Electron process
+        # just to IPC to the running instance (~300 ms cold overhead per keypress).
+        #
+        # Solution: on startup the app creates a Unix domain socket at
+        # /run/user/<uid>/claude-desktop-qe.sock. Any connection toggles Quick Entry in
+        # ~5-25 ms (no process spawn). The packaged `claude-desktop-toggle` script tries
+        # socat (~2 ms) or python3 (~25 ms) first, then falls back to the old Electron
+        # path when the app is not running.
+        #
+        # Hotkey command: claude-desktop-toggle   (installed in /usr/bin by all packages)
+        #
+        # Falls back gracefully: if /run/user/ is unavailable the try/catch swallows
+        # the error and the old --toggle-quick-entry path continues to work.
+        let socketTrigger =
+          ",(()=>{" &
+          "if(process.platform!==\"linux\")return;" &
+          "try{" &
+          "const _qeS=`/run/user/${process.getuid()}/claude-desktop-qe.sock`;" &
+          "try{require(\"fs\").unlinkSync(_qeS)}catch(e){}" &
+          "require(\"net\").createServer(c=>{" &
+          "c.on(\"error\",()=>{});" &
+          "c.end();" &
+          "try{if(globalThis." & HANDLER_GLOBAL & ")globalThis." & HANDLER_GLOBAL & "()}catch(e){}" &
+          "}).listen(_qeS);" &
+          "if(!globalThis.__qeTriggerLogged){globalThis.__qeTriggerLogged=true;" &
+          "console.log(\"[quick-entry] socket trigger ready: \"+_qeS)}" &
+          "}catch(e){}" &
+          "})()"
+
+        resultStr &= regFn & "(" & enumVar & ".QUICK_ENTRY," & assign & ")" & firstInstance & socketTrigger
         lastEnd = bounds.b + 1
         inc countA
         break

--- a/patches/fix_quick_entry_cli_toggle.nim
+++ b/patches/fix_quick_entry_cli_toggle.nim
@@ -52,7 +52,7 @@ proc apply*(input: string): string =
           ")globalThis." &
           HANDLER_GLOBAL &
           "()}catch(e){}" &
-          "},500)"
+          "},250)"
 
         resultStr &= regFn & "(" & enumVar & ".QUICK_ENTRY," & assign & ")" & firstInstance
         lastEnd = bounds.b + 1

--- a/patches/fix_quick_entry_position.nim
+++ b/patches/fix_quick_entry_position.nim
@@ -13,14 +13,14 @@ proc cursorIife(electronVar: string): string =
   "const cp=require(\"child_process\");" &
   "try{" &
   "const r=cp.execFileSync(\"xdotool\",[\"getmouselocation\",\"--shell\"]," &
-  "{timeout:100,encoding:\"utf-8\"});" &
+  "{timeout:200,encoding:\"utf-8\"});" &
   "const x=parseInt(r.match(/X=(\\d+)/)?.[1]);" &
   "const y=parseInt(r.match(/Y=(\\d+)/)?.[1]);" &
   "if(!isNaN(x)&&!isNaN(y)){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using xdotool\")}return{x,y}}" &
   "}catch(e){}" &
   "try{" &
   "const r=cp.execFileSync(\"hyprctl\",[\"cursorpos\"]," &
-  "{timeout:100,encoding:\"utf-8\"});" &
+  "{timeout:200,encoding:\"utf-8\"});" &
   "const m=r.match(/(\\d+),\\s*(\\d+)/);" &
   "if(m){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using hyprctl\")}return{x:parseInt(m[1]),y:parseInt(m[2])}}" &
   "}catch(e){}" &

--- a/patches/fix_quick_entry_position.nim
+++ b/patches/fix_quick_entry_position.nim
@@ -13,14 +13,14 @@ proc cursorIife(electronVar: string): string =
   "const cp=require(\"child_process\");" &
   "try{" &
   "const r=cp.execFileSync(\"xdotool\",[\"getmouselocation\",\"--shell\"]," &
-  "{timeout:200,encoding:\"utf-8\"});" &
+  "{timeout:100,encoding:\"utf-8\"});" &
   "const x=parseInt(r.match(/X=(\\d+)/)?.[1]);" &
   "const y=parseInt(r.match(/Y=(\\d+)/)?.[1]);" &
   "if(!isNaN(x)&&!isNaN(y)){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using xdotool\")}return{x,y}}" &
   "}catch(e){}" &
   "try{" &
   "const r=cp.execFileSync(\"hyprctl\",[\"cursorpos\"]," &
-  "{timeout:200,encoding:\"utf-8\"});" &
+  "{timeout:100,encoding:\"utf-8\"});" &
   "const m=r.match(/(\\d+),\\s*(\\d+)/);" &
   "if(m){if(!globalThis.__qeCursorLogged){globalThis.__qeCursorLogged=true;console.log(\"[quick-entry] cursor: using hyprctl\")}return{x:parseInt(m[1]),y:parseInt(m[2])}}" &
   "}catch(e){}" &

--- a/patches/fix_quick_entry_position.nim
+++ b/patches/fix_quick_entry_position.nim
@@ -83,7 +83,11 @@ proc apply*(input: string): string =
   else:
     echo "  [INFO] position restore override: 0 matches (older version without saved position)"
 
-  # Patch 4: Fix show/positioning + focus on Linux -- uses \1, \2 backreferences
+  # Patch 4: Fix show/positioning + focus on Linux -- uses \1, \2 backreferences.
+  # The 50/150/300 ms retries (moveTop + setBounds + focus) are gated behind _isX11.
+  # On Wayland the compositor never repositions windows after show(), so the retries
+  # were pointless and caused visible jitter on every open. On X11 (WM smart placement)
+  # they are still needed to fight back-to-front reordering.
   let pattern4 = nre.re"([\w$]+)\.show\(\)\}return \1\.setPosition\(Math\.round\(([\w$]+)\.x\),Math\.round\(\2\.y\)\),!0\}"
   let m4 = result.find(pattern4)
   if m4.isSome:
@@ -117,9 +121,11 @@ proc apply*(input: string): string =
       w & ".show();" &
       "_r();" &
       "_ff();" &
+      "if(_isX11){" &
       "setTimeout(()=>{if(!" & w & ".isDestroyed()){_r();_ff()}},50);" &
       "setTimeout(()=>{if(!" & w & ".isDestroyed()){_r();_ff()}},150);" &
       "setTimeout(()=>{if(!" & w & ".isDestroyed()){_r();_ff()}},300)" &
+      "}" &
       "})()}" &
       "return!0}"
     result = result[0 ..< m.matchBounds.a] & replacement & result[m.matchBounds.b + 1 .. ^1]

--- a/patches/fix_quick_entry_ready_wayland.nim
+++ b/patches/fix_quick_entry_ready_wayland.nim
@@ -7,11 +7,10 @@
 # BrowserWindows on native Wayland. The Quick Entry window (Mlr function)
 # awaits this event indefinitely, causing the overlay to never appear.
 #
-# This patch adds a 100ms timeout to the ready-to-show wait so the Quick
+# This patch adds a 200ms timeout to the ready-to-show wait so the Quick
 # Entry window proceeds to show even if the event never fires.
-# The timeout is 100ms (reduced from 200ms): Chromium first-paint on Wayland
-# typically completes in 30-50ms, so 100ms still provides comfortable headroom
-# while saving 100ms on every Quick Entry open.
+# The timeout is 200ms: Chromium first-paint on Wayland typically completes
+# in 30-50ms, so 200ms provides comfortable headroom.
 
 import std/[os, strutils, options]
 import std/nre
@@ -20,7 +19,7 @@ proc apply*(input: string): string =
   # The Quick Entry show function waits for ready-to-show:
   #   <VAR>||await(<VAR2>==null?void 0:<VAR2>.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}))
   # Variable names change every release (NEe/YEe, nK/AK, etc.).
-  # We wrap this in Promise.race with a 100ms timeout.
+  # We wrap this in Promise.race with a 200ms timeout.
   let pat = re"""([\w$]+)\|\|await\(([\w$]+)==null\?void 0:\2\.catch\([\w$]+=>\{[\w$]+\.error\("Quick Entry: Error waiting for ready %o",\{error:[\w$]+\}\)\}\)\)"""
 
   let m = input.find(pat)
@@ -28,9 +27,9 @@ proc apply*(input: string): string =
     let match = m.get
     let flagVar = match.captures[0]
     let promiseVar = match.captures[1]
-    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,100))])"""
+    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,200))])"""
     result = input[0 ..< match.matchBounds.a] & newStr & input[match.matchBounds.b + 1 .. ^1]
-    echo "  [OK] ready-to-show timeout (100ms) added (vars: " & flagVar & ", " & promiseVar & ")"
+    echo "  [OK] ready-to-show timeout (200ms) added (vars: " & flagVar & ", " & promiseVar & ")"
   else:
     echo "  [FAIL] ready-to-show wait pattern not found"
     quit(1)

--- a/patches/fix_quick_entry_ready_wayland.nim
+++ b/patches/fix_quick_entry_ready_wayland.nim
@@ -7,7 +7,7 @@
 # BrowserWindows on native Wayland. The Quick Entry window (Mlr function)
 # awaits this event indefinitely, causing the overlay to never appear.
 #
-# This patch adds a 200ms timeout to the ready-to-show wait so the Quick
+# This patch adds a 100ms timeout to the ready-to-show wait so the Quick
 # Entry window proceeds to show even if the event never fires.
 
 import std/[os, strutils, options]
@@ -17,7 +17,7 @@ proc apply*(input: string): string =
   # The Quick Entry show function waits for ready-to-show:
   #   <VAR>||await(<VAR2>==null?void 0:<VAR2>.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}))
   # Variable names change every release (NEe/YEe, nK/AK, etc.).
-  # We wrap this in Promise.race with a 200ms timeout.
+  # We wrap this in Promise.race with a 100ms timeout.
   let pat = re"""([\w$]+)\|\|await\(([\w$]+)==null\?void 0:\2\.catch\([\w$]+=>\{[\w$]+\.error\("Quick Entry: Error waiting for ready %o",\{error:[\w$]+\}\)\}\)\)"""
 
   let m = input.find(pat)
@@ -25,9 +25,9 @@ proc apply*(input: string): string =
     let match = m.get
     let flagVar = match.captures[0]
     let promiseVar = match.captures[1]
-    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,200))])"""
+    let newStr = flagVar & "||await Promise.race([" & promiseVar & "==null?void 0:" & promiseVar & """.catch(n=>{R.error("Quick Entry: Error waiting for ready %o",{error:n})}),new Promise(_r=>setTimeout(_r,100))])"""
     result = input[0 ..< match.matchBounds.a] & newStr & input[match.matchBounds.b + 1 .. ^1]
-    echo "  [OK] ready-to-show timeout (200ms) added (vars: " & flagVar & ", " & promiseVar & ")"
+    echo "  [OK] ready-to-show timeout (100ms) added (vars: " & flagVar & ", " & promiseVar & ")"
   else:
     echo "  [FAIL] ready-to-show wait pattern not found"
     quit(1)

--- a/patches/fix_quick_entry_ready_wayland.nim
+++ b/patches/fix_quick_entry_ready_wayland.nim
@@ -9,6 +9,9 @@
 #
 # This patch adds a 100ms timeout to the ready-to-show wait so the Quick
 # Entry window proceeds to show even if the event never fires.
+# The timeout is 100ms (reduced from 200ms): Chromium first-paint on Wayland
+# typically completes in 30-50ms, so 100ms still provides comfortable headroom
+# while saving 100ms on every Quick Entry open.
 
 import std/[os, strutils, options]
 import std/nre

--- a/scripts/build-patched-tarball.sh
+++ b/scripts/build-patched-tarball.sh
@@ -278,6 +278,10 @@ cp -r "$WORK_DIR/app"/* "$TARBALL_DIR/app/"
 cp "$SCRIPT_DIR/claude-desktop-launcher.sh" "$TARBALL_DIR/launcher/claude-desktop"
 chmod +x "$TARBALL_DIR/launcher/claude-desktop"
 
+# Copy Quick Entry toggle helper
+cp "$SCRIPT_DIR/claude-desktop-toggle.sh" "$TARBALL_DIR/launcher/claude-desktop-toggle"
+chmod +x "$TARBALL_DIR/launcher/claude-desktop-toggle"
+
 # Validate launcher with shellcheck (catches shebang issues, syntax errors, common bugs)
 if command -v shellcheck &>/dev/null; then
     if ! shellcheck -S error "$TARBALL_DIR/launcher/claude-desktop"; then

--- a/scripts/claude-desktop-launcher.sh
+++ b/scripts/claude-desktop-launcher.sh
@@ -133,10 +133,10 @@ print(repr(arr))
     gsettings set "$GNOME_HOTKEY_ROOT" custom-keybindings "$new_array"
     # Per-slot schema writes. Use ':' form to scope the schema to our slot.
     gsettings set "${GNOME_HOTKEY_ROOT}.custom-keybinding:${GNOME_HOTKEY_SLOT}" name 'Claude Desktop Quick Entry'
-    gsettings set "${GNOME_HOTKEY_ROOT}.custom-keybinding:${GNOME_HOTKEY_SLOT}" command 'claude-desktop --toggle-quick-entry'
+    gsettings set "${GNOME_HOTKEY_ROOT}.custom-keybinding:${GNOME_HOTKEY_SLOT}" command 'claude-desktop-toggle'
     gsettings set "${GNOME_HOTKEY_ROOT}.custom-keybinding:${GNOME_HOTKEY_SLOT}" binding "$accel"
 
-    echo "Installed GNOME hotkey: $accel → claude-desktop --toggle-quick-entry"
+    echo "Installed GNOME hotkey: $accel → claude-desktop-toggle"
     echo "Test it by pressing $accel from any window (Claude does not need to be focused)."
     echo "To change the accelerator later: claude-desktop --install-gnome-hotkey '<Super>space'"
     echo "To remove: claude-desktop --uninstall-gnome-hotkey"

--- a/scripts/claude-desktop-toggle.sh
+++ b/scripts/claude-desktop-toggle.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# claude-desktop-toggle -- fast Quick Entry toggle for Claude Desktop on Linux.
+#
+# Connects to the Unix domain socket that Claude Desktop creates at startup.
+# This bypasses the Electron process-spawn path and toggles Quick Entry in
+# ~5-25 ms instead of ~300 ms.
+#
+# Usage: set this as your keyboard shortcut command instead of
+#   claude-desktop --toggle-quick-entry
+#
+# Fallback: if the socket does not exist (Claude Desktop not running),
+# falls through to `claude-desktop --toggle-quick-entry` which starts the app.
+
+SOCK="/run/user/$(id -u)/claude-desktop-qe.sock"
+
+if [ -S "$SOCK" ]; then
+    # Try socat first (~2 ms startup), fall back to python3 (~25 ms startup).
+    if command -v socat >/dev/null 2>&1; then
+        socat /dev/null "UNIX-CLIENT:$SOCK" 2>/dev/null && exit 0
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c "
+import socket, os, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(0.5)
+s.connect(sys.argv[1])
+s.sendall(b'1')
+s.close()
+" "$SOCK" 2>/dev/null && exit 0
+    fi
+fi
+
+# Fallback: standard Electron second-instance path (also starts the app if needed).
+exec claude-desktop --toggle-quick-entry


### PR DESCRIPTION
Closes #47

## Finding the root cause

Quick Entry had a ~300 ms opening delay. The obvious suspects were the compositor and the app's JS. Both were instrumented with timestamps:

```
[QE-BEFORE-SHOW] 1776552389350
[QE-SHOW-EVT]    1776552389351   Delta show():  1 ms
[QE-BEFORE-HIDE] 1776552393003
[QE-HIDE-EVT]    1776552393014   Delta hide(): 11 ms
```

JS overhead from handler call to `show()` is ~1 ms. Mutter/KWin responds to map/unmap in < 1 ms. Neither is the bottleneck. With both ruled out the only remaining candidate is the hotkey trigger itself: every press runs `claude-desktop --toggle-quick-entry`, which spawns a full Electron process (~300 ms startup), detects the running instance, sends a `second-instance` IPC, and exits. That spawn cost is unavoidable when going through Electron and accounts for the entire delay.

This specifically affects GNOME users: the package ships `--install-gnome-hotkey` which automatically registers `claude-desktop --toggle-quick-entry` as the keyboard shortcut via `gsettings`. That is the only automated hotkey setup in this package. On KDE, Hyprland, and other Wayland desktops Electron registers the shortcut directly via the `xdg-desktop-portal` `GlobalShortcuts` API — keypresses are delivered as portal events to the already-running process, no subprocess spawned. On GNOME, `--install-gnome-hotkey` uses GNOME's custom keybinding system (`gsettings`) which runs an external command on every press, and that command is `claude-desktop --toggle-quick-entry`.

## What was investigated and ruled out

**Always-mapped window (opacity toggle instead of show/hide)**

Given the measurements above, keeping the window always mapped would save 0 ms. The compositor overhead is already < 1 ms. Dropped.

**`fs.watch` on a trigger file**

The first fast-path attempt watched a file with `fs.watch`. Writing to the file from the hotkey script would call `__ceQuickEntryShow()` inside the running app without spawning Electron. In testing this was unreliable: sometimes instant, sometimes hundreds of milliseconds delayed, sometimes the event never fired at all.

**`fs.watch` on a directory**

Switching to a directory watch was tried as a workaround. Same result — non-deterministic latency, events sometimes missed entirely.

The root cause of both failures is how Electron processes file I/O events. `fs.watch` is backed by libuv's inotify integration, whose callbacks must go through libuv's thread pool and then be posted back to the main thread via Chromium's message pump. Chromium's message pump prioritises UI work — rendering, input, IPC — over thread pool callbacks. When the Electron process is doing anything at all, file I/O callbacks can be delayed arbitrarily. This is non-deterministic and cannot be fixed from patch code.

Network socket events go through a different path: libuv's network I/O uses epoll via a dedicated I/O thread that is not subject to Chromium's message pump prioritisation. Socket events are delivered promptly regardless of what the main thread is doing. That is why the socket approach is reliable where `fs.watch` is not.

## Changes

### Unix domain socket trigger (`fix_quick_entry_cli_toggle.nim`, sub-patch D)

On startup the app creates a Unix domain socket at `/run/user/<uid>/claude-desktop-qe.sock` via Node.js `net.createServer`. Any incoming connection calls `__ceQuickEntryShow()` directly and closes immediately — no process spawn, no IPC roundtrip, no persistent connection.

The socket file is cleaned up with `unlinkSync` before each `listen()` call so stale sockets from a previous crash don't block startup. The entire setup is wrapped in try/catch so failures (e.g. `/run/user/` unavailable) are silently swallowed and the existing `--toggle-quick-entry` path continues to work.

#### `claude-desktop-toggle` script

A new shell script is installed to `/usr/bin/claude-desktop-toggle` by all package formats. Its logic:

```
1. Check if /run/user/<uid>/claude-desktop-qe.sock exists as a socket file
   NO  → exec claude-desktop --toggle-quick-entry  (starts the app if not running)
   YES →
     2a. socat /dev/null UNIX-CLIENT:<sock>             (~2 ms, optional)
         success → exit 0
     2b. python3 -c "connect + sendall(b'1') + close"  (~25 ms, always available)
         success → exit 0
     2c. exec claude-desktop --toggle-quick-entry       (safety fallback, e.g. stale socket)
```

`python3` is the primary no-dependency client because it is always present on any supported Linux distribution. `socat` is tried first when available because its startup is faster. Step 2c handles the case where the socket file exists but the connection fails (app crashed and left a stale socket).

**Result: ~5–25 ms per keypress instead of ~300 ms.**

**Side effect: the GNOME double-fire regression (issue #38) is eliminated.** That regression occurred because `claude-desktop --toggle-quick-entry` triggered `second-instance`, which GNOME sometimes delivered twice, toggling the window open and immediately closed. With the socket approach, `second-instance` is never triggered while the app is running — nothing left to double-fire.

### Wayland retry gate (`fix_quick_entry_position.nim`)

The 50/150/300 ms position+focus retries are now gated behind `_isX11`. On X11, WM smart-placement can reposition windows after `show()` so retries are still needed. On Wayland the compositor never repositions, so the retries only caused visible jitter on every open with no benefit. X11 behaviour is unchanged.

### Packaging

`claude-desktop-toggle` is installed to `/usr/bin` in all package formats: AUR, RPM, DEB, AppImage, and NixOS (generated inline in `installPhase`, wrapped with socat/python3 via `wrapProgram`).

`--install-gnome-hotkey` now writes `claude-desktop-toggle` into the gsettings slot instead of `claude-desktop --toggle-quick-entry`.

## Migration

**GNOME users** who previously ran `--install-gnome-hotkey` need to run it once again:

```bash
claude-desktop --install-gnome-hotkey
```

Users on KDE, Sway, Hyprland, or X11 who manually set their shortcut command to `claude-desktop --toggle-quick-entry` should update it to `claude-desktop-toggle`. The old command continues to work as the fallback inside the script.

## Tested on

- Fedora 43, GNOME Wayland