### PR TITLE
Fix "Start at login" toggle broken on Linux: implement XDG autostart

### DIFF
--- a/patches/fix_startup_settings.nim
+++ b/patches/fix_startup_settings.nim
@@ -1,14 +1,21 @@
 # @patch-target: app.asar.contents/.vite/build/index.js
 # @patch-type: nim
 #
-# Patch Claude Desktop to fix startup settings on Linux.
+# Patch Claude Desktop to fix "Start at login" / "Start in system tray" on Linux.
 #
-# On Linux, Electron's app.getLoginItemSettings() returns undefined values for
-# openAtLogin and executableWillLaunchAtLogin, causing validation errors.
-# This patch adds a Linux platform check to return false immediately.
+# Problem (three layers):
+# 1. isStartupOnLoginEnabled() must not call Electron's getLoginItemSettings() on Linux
+#    because it returns undefined values for openAtLogin/executableWillLaunchAtLogin,
+#    causing the Settings toggle to always show as disabled.
+# 2. setStartupOnLoginEnabled() must manage the XDG autostart file directly, because
+#    Electron's setLoginItemSettings() on Linux does not add --startup to the Exec line,
+#    so the main window would always appear even when started at login.
+# 3. The main window is only hidden when argv.includes("--startup") is true (Linux path).
+#    Without --startup in the autostart Exec line, the window always shows.
 #
-# Linux autostart is typically handled via .desktop files in ~/.config/autostart/
-# which is outside the app's control anyway.
+# Fix:
+# - isStartupOnLoginEnabled(): check ~/.config/autostart/com.anthropic.claude-desktop.desktop
+# - setStartupOnLoginEnabled(enabled): create/remove that file with Exec=claude-desktop --startup
 
 import std/[os, strutils]
 import regex
@@ -18,39 +25,54 @@ proc apply*(input: string): string =
   const expectedPatches = 2
 
   # Pattern 1: isStartupOnLoginEnabled function
-  # Add Linux platform check before the existing env var check
+  # Replace the env-var short-circuit with a Linux XDG check, then keep the env-var check.
   let pattern1 = re2"""isStartupOnLoginEnabled\(\)\{if\(process\.env\.CLAUDE_AVOID_READING_LOGING_ITEM_SETTINGS\)return!1;"""
-  let replacement1 = """isStartupOnLoginEnabled(){if(process.platform==="linux"||process.env.CLAUDE_AVOID_READING_LOGING_ITEM_SETTINGS)return!1;"""
+  const replacement1 = """isStartupOnLoginEnabled(){if(process.platform==="linux"){try{return require("fs").existsSync(require("path").join(require("os").homedir(),".config","autostart","com.anthropic.claude-desktop.desktop"))}catch(e){return false}}if(process.env.CLAUDE_AVOID_READING_LOGING_ITEM_SETTINGS)return!1;"""
 
-  var count1 = 0
-  result = input.replace(pattern1, proc(m: RegexMatch2, s: string): string =
-    inc count1
-    replacement1
-  )
-  if count1 > 0:
-    patchesApplied += count1
-    echo "  [OK] isStartupOnLoginEnabled: " & $count1 & " match(es)"
+  # Already-applied sentinel: Pattern 1 changes the function to start with platform check.
+  # Must be specific - other patches (fix_asar_workspace_cwd, fix_browser_tools_linux)
+  # also inject require("os").homedir(), so that alone is not a reliable sentinel.
+  if """isStartupOnLoginEnabled(){if(process.platform==="linux")""" in input:
+    echo "  [INFO] isStartupOnLoginEnabled: already patched"
+    patchesApplied += 1
+    result = input
   else:
-    echo "  [FAIL] isStartupOnLoginEnabled: 0 matches"
+    var count1 = 0
+    result = input.replace(pattern1, proc(m: RegexMatch2, s: string): string =
+      inc count1
+      replacement1
+    )
+    if count1 > 0:
+      patchesApplied += count1
+      echo "  [OK] isStartupOnLoginEnabled: " & $count1 & " match(es)"
+    else:
+      echo "  [FAIL] isStartupOnLoginEnabled: 0 matches"
 
-  # Pattern 2: setStartupOnLoginEnabled function - make it a no-op on Linux
-  let pattern2 = re2"""setStartupOnLoginEnabled\(([\w$]+)\)\{([\w$]+)\.debug\("""
-  var count2 = 0
+  # Pattern 2: setStartupOnLoginEnabled function
+  # Inject Linux XDG autostart file management (create/remove with --startup in Exec line).
+  let pattern2 = re2"""setStartupOnLoginEnabled\(([\w$]+)\)\{([\w$]+)\.debug\("Toggling"""
+
+  # Already-applied sentinel: Pattern 2 adds X-GNOME-Autostart-enabled (unique to our patch)
   let intermediate = result
-  result = intermediate.replace(pattern2, proc(m: RegexMatch2, s: string): string =
-    inc count2
-    let argVar = s[m.group(0)]
-    let loggerVar = s[m.group(1)]
-    "setStartupOnLoginEnabled(" & argVar & """){if(process.platform==="linux")return;""" & loggerVar & ".debug("
-  )
-  if count2 > 0:
-    patchesApplied += count2
-    echo "  [OK] setStartupOnLoginEnabled: " & $count2 & " match(es)"
+  if "X-GNOME-Autostart-enabled" in input:
+    echo "  [INFO] setStartupOnLoginEnabled: already patched"
+    patchesApplied += 1
   else:
-    echo "  [INFO] setStartupOnLoginEnabled: 0 matches (optional)"
+    var count2 = 0
+    result = intermediate.replace(pattern2, proc(m: RegexMatch2, s: string): string =
+      inc count2
+      let argVar = s[m.group(0)]
+      let loggerVar = s[m.group(1)]
+      """setStartupOnLoginEnabled(""" & argVar & """){if(process.platform==="linux"){const _f=require("path").join(require("os").homedir(),".config","autostart","com.anthropic.claude-desktop.desktop");if(""" & argVar & """){require("fs").mkdirSync(require("path").dirname(_f),{recursive:true});require("fs").writeFileSync(_f,"[Desktop Entry]\nType=Application\nName=Claude\nExec=claude-desktop --startup\nX-GNOME-Autostart-enabled=true\n")}else{try{require("fs").unlinkSync(_f)}catch(e){}}return}""" & loggerVar & """.debug("Toggling"""
+    )
+    if count2 > 0:
+      patchesApplied += count2
+      echo "  [OK] setStartupOnLoginEnabled: " & $count2 & " match(es)"
+    else:
+      echo "  [FAIL] setStartupOnLoginEnabled: 0 matches"
 
   if patchesApplied < expectedPatches:
-    echo "  [FAIL] Only " & $patchesApplied & "/" & $expectedPatches & " patches applied -- check [WARN]/[FAIL] messages above"
+    echo "  [FAIL] Only " & $patchesApplied & "/" & $expectedPatches & " patches applied"
     quit(1)
 
 when isMainModule:


### PR DESCRIPTION
Fixes #60.

## Problem (three layers)

**Layer 1 - our own patch was too aggressive:**
The previous `fix_startup_settings.nim` made `isStartupOnLoginEnabled()` always return `false` on Linux and `setStartupOnLoginEnabled()` a no-op. This caused:
- The Settings toggle to always show as *disabled* regardless of reality
- No autostart entry to ever be created when the user toggled it on

**Layer 2 - upstream code doesn't pass `--startup` on Linux:**
Even without our patch, `setStartupOnLoginEnabled()` calls Electron's `app.setLoginItemSettings({openAtLogin, path: det()})`. On Linux, `det()` returns `process.execPath` with no extra arguments (the `--startup` flag is only appended on Windows). So any XDG autostart file written by Electron would have `Exec=<electron-binary>` with no flags.

**Layer 3 - window visibility depends on `--startup`:**
The main window is only hidden when `argv.includes("--startup")` is true (Linux path). In v1.3883.0:

```js
const mLn = !(zr
  ? app.getLoginItemSettings().wasOpenedAtLogin   // macOS
  : nc.argv.includes("--startup"))               // Linux / Windows
```

Without `--startup` in the autostart `Exec=` line, `mLn` is always `true` and the main window always appears even when launched at login.

## Fix

Replace both Linux no-op paths with direct XDG autostart file management.

**`isStartupOnLoginEnabled()` on Linux:**
Checks whether `~/.config/autostart/com.anthropic.claude-desktop.desktop` exists. Returns `true`/`false` accordingly so the Settings toggle correctly reflects reality.

**`setStartupOnLoginEnabled(enabled)` on Linux:**
- `enabled=true`: Creates `~/.config/autostart/com.anthropic.claude-desktop.desktop` with:
  ```ini
  [Desktop Entry]
  Type=Application
  Name=Claude
  Exec=claude-desktop --startup
  X-GNOME-Autostart-enabled=true
  ```
- `enabled=false`: Removes the file if it exists.

The `claude-desktop` launcher passes all arguments through to Electron (`exec ... "$@"`), so `--startup` reaches the JS layer where `argv.includes("--startup")` becomes `true`, keeping the main window hidden on login startup.

**Sentinel fix:**
The already-applied detection for Pattern 1 now checks for the patched function signature (`isStartupOnLoginEnabled(){if(process.platform==="linux")`) rather than `require("os").homedir()`. Other patches (`fix_asar_workspace_cwd`, `fix_browser_tools_linux`) also inject `require("os").homedir()` into the file before this patch runs, which caused Pattern 1 to be silently skipped in the previous iteration.

## Testing

Tested on Fedora 43 with KDE/X11 and GNOME:
1. Enable "Start at login" in Settings - toggle stays enabled after reopening Settings
2. `~/.config/autostart/com.anthropic.claude-desktop.desktop` is created with correct content
3. On next login, app starts hidden in system tray (no main window shown)
4. Disable the setting - file is removed, toggle shows disabled