### PR TITLE
Fix patch patterns for Claude Desktop v1.4758.0

### DIFF
--- a/patches/enable_local_agent_mode.nim
+++ b/patches/enable_local_agent_mode.nim
@@ -30,15 +30,13 @@ proc apply*(input: string): string =
   var patchesApplied = 0
 
   # Patch 1: Remove platform!=="darwin" gate from chillingSlothFeat and quietPenguin
-  let pattern1 =
-    re"""(function )([\w$]+)(\(\)\{return )process\.platform!=="darwin"\?\{status:"unavailable"\}:(\{status:"supported"\}\})"""
+  let pattern1 = re"""(function )([\w$]+)(\(\)\{return )process\.platform!=="darwin"\?\{status:"unavailable"\}:(\{status:"supported"\}\})"""
 
   var matches: seq[RegexMatch] = @[]
   var pos = 0
   while true:
     let m = result.find(pattern1, pos)
-    if m.isNone:
-      break
+    if m.isNone: break
     matches.add(m.get())
     pos = m.get().matchBounds.b + 1
 
@@ -67,22 +65,18 @@ proc apply*(input: string): string =
     quit(1)
 
   # Patch 1b: Bypass yukonSilver (NH) platform gate on Linux
-  let nhPatternOld =
-    re"""(function [\w$]+\(\)\{)(const ([\w$]+)=process\.platform;if\(\3!=="darwin"&&\3!=="win32"\)return\{status:"unsupported",reason:`Unsupported platform: \$\{\3\}`\})"""
-  let nhPatternNew =
-    re"""(function [\w$]+\(\)\{)(const ([\w$]+)=process\.platform;if\(\3!=="darwin"&&\3!=="win32"\)return\{status:"unsupported",reason:[\w$]+\.formatMessage\(\{defaultMessage:"Cowork is not currently supported on \{platform\}"(?:,id:"[^"]*")?\},\{platform:[\w$]+\(\)\}\),unsupportedCode:"unsupported_platform"\};)"""
+  let nhPatternOld = re"""(function [\w$]+\(\)\{)(const ([\w$]+)=process\.platform;if\(\3!=="darwin"&&\3!=="win32"\)return\{status:"unsupported",reason:`Unsupported platform: \$\{\3\}`\})"""
+  # reason: can be either Qe.formatMessage (old) or Qe().formatMessage (new, v1.4758+)
+  let nhPatternNew = re"""(function [\w$]+\(\)\{)(const ([\w$]+)=process\.platform;if\(\3!=="darwin"&&\3!=="win32"\)return\{status:"unsupported",reason:[\w$]+(?:\(\))?\.formatMessage\(\{defaultMessage:"Cowork is not currently supported on \{platform\}"(?:,id:"[^"]*")?\},\{platform:[\w$]+\(\)\}\),unsupportedCode:"unsupported_platform"\};)"""
 
   if "if(process.platform===\"linux\")return{status:\"supported\"};const" in result:
     echo "  [OK] yukonSilver (NH): already patched"
     inc patchesApplied
   else:
     var count1b = 0
-    let nhResult = result.replace(
-      nhPatternOld,
-      proc(m: RegexMatch): string =
-        inc count1b
-        m.captures[0] & "if(process.platform===\"linux\")return{status:\"supported\"};" &
-          m.captures[1],
+    let nhResult = result.replace(nhPatternOld, proc(m: RegexMatch): string =
+      inc count1b
+      m.captures[0] & "if(process.platform===\"linux\")return{status:\"supported\"};" & m.captures[1]
     )
     if count1b >= 1:
       result = nhResult
@@ -90,12 +84,9 @@ proc apply*(input: string): string =
       inc patchesApplied
     else:
       var count1bNew = 0
-      let nhResult2 = result.replace(
-        nhPatternNew,
-        proc(m: RegexMatch): string =
-          inc count1bNew
-          m.captures[0] & "if(process.platform===\"linux\")return{status:\"supported\"};" &
-            m.captures[1],
+      let nhResult2 = result.replace(nhPatternNew, proc(m: RegexMatch): string =
+        inc count1bNew
+        m.captures[0] & "if(process.platform===\"linux\")return{status:\"supported\"};" & m.captures[1]
       )
       if count1bNew >= 1:
         result = nhResult2
@@ -110,8 +101,7 @@ proc apply*(input: string): string =
   inc patchesApplied
 
   # Patch 3: Override features in mC() async merger
-  let overrides =
-    ",quietPenguin:{status:\"supported\"},louderPenguin:{status:\"supported\"},chillingSlothFeat:{status:\"supported\"},chillingSlothLocal:{status:\"supported\"},yukonSilver:{status:\"supported\"},yukonSilverGems:{status:\"supported\"},ccdPlugins:{status:\"supported\"},computerUse:{status:\"supported\"},coworkKappa:{status:\"supported\"},coworkArtifacts:{status:\"supported\"}"
+  let overrides = ",quietPenguin:{status:\"supported\"},louderPenguin:{status:\"supported\"},chillingSlothFeat:{status:\"supported\"},chillingSlothLocal:{status:\"supported\"},yukonSilver:{status:\"supported\"},yukonSilverGems:{status:\"supported\"},ccdPlugins:{status:\"supported\"},computerUse:{status:\"supported\"},coworkKappa:{status:\"supported\"},coworkArtifacts:{status:\"supported\"}"
 
   # New format: return{...FUNC(),...props}};
   let pattern3New = re"(return\{\.\.\.(?:[\w$]+)\(\),[^}]+)(\}\};)"
@@ -125,16 +115,12 @@ proc apply*(input: string): string =
     inc patchesApplied
   else:
     # Fallback: old format
-    let pattern3Old =
-      re"(const [\w$]+=async\(\)=>\(\{\.\.\.[\w$]+\(\),[^}]+)(await [\w$]+\(\))\}\)"
+    let pattern3Old = re"(const [\w$]+=async\(\)=>\(\{\.\.\.[\w$]+\(\),[^}]+)(await [\w$]+\(\))\}\)"
     var count3 = 0
-    result = result.replace(
-      pattern3Old,
-      proc(m: RegexMatch): string =
-        inc count3
-        if count3 > 1:
-          return m.match
-        m.captures[0] & m.captures[1] & overrides & "})",
+    result = result.replace(pattern3Old, proc(m: RegexMatch): string =
+      inc count3
+      if count3 > 1: return m.match
+      m.captures[0] & m.captures[1] & overrides & "})"
     )
     if count3 >= 1:
       echo &"  [OK] mC() feature merger: 10 features overridden (old format, {count3} match)"
@@ -146,11 +132,9 @@ proc apply*(input: string): string =
   # Patch 3b: Enable coworkKappa GrowthBook flag (123929380) on Linux
   let kappaPattern = re"""[\w$]+\("123929380"\)"""
   var kappaApplied = 0
-  result = result.replace(
-    kappaPattern,
-    proc(m: RegexMatch): string =
-      inc kappaApplied
-      "!0",
+  result = result.replace(kappaPattern, proc(m: RegexMatch): string =
+    inc kappaApplied
+    "!0"
   )
   if kappaApplied >= 3:
     echo &"  [OK] coworkKappa flag 123929380: forced ON ({kappaApplied} matches)"
@@ -165,11 +149,9 @@ proc apply*(input: string): string =
   # Patch 3c: Enable coworkArtifacts GrowthBook flag (2940196192) on Linux
   let artifactsPattern = re"""[\w$]+\("2940196192"\)"""
   var artifactsApplied = 0
-  result = result.replace(
-    artifactsPattern,
-    proc(m: RegexMatch): string =
-      inc artifactsApplied
-      "!0",
+  result = result.replace(artifactsPattern, proc(m: RegexMatch): string =
+    inc artifactsApplied
+    "!0"
   )
   if artifactsApplied >= 3:
     echo &"  [OK] coworkArtifacts flag 2940196192: forced ON ({artifactsApplied} matches)"
@@ -198,21 +180,15 @@ proc apply*(input: string): string =
     quit(1)
 
   # Patch 5: Spoof platform as "darwin" in HTTP headers
-  let headerPattern =
-    re"(const [\w$]+=[\w$]+\.app\.getVersion\(\),)([\w$]+)(=)([\w$]+)(\.platform,)([\w$]+)(=\4\.getSystemVersion\(\)[;,])"
+  let headerPattern = re"(const [\w$]+=[\w$]+\.app\.getVersion\(\),)([\w$]+)(=)([\w$]+)(\.platform,)([\w$]+)(=\4\.getSystemVersion\(\)[;,])"
   var count5 = 0
-  result = result.replace(
-    headerPattern,
-    proc(m: RegexMatch): string =
-      inc count5
-      if count5 > 1:
-        return m.match
-      let platVar = m.captures[1]
-      let osMod = m.captures[3]
-      let verVar = m.captures[5]
-      m.captures[0] & platVar & m.captures[2] &
-        "process.platform===\"linux\"?\"darwin\":" & osMod & m.captures[4] & verVar &
-        m.captures[6],
+  result = result.replace(headerPattern, proc(m: RegexMatch): string =
+    inc count5
+    if count5 > 1: return m.match
+    let platVar = m.captures[1]
+    let osMod = m.captures[3]
+    let verVar = m.captures[5]
+    m.captures[0] & platVar & m.captures[2] & "process.platform===\"linux\"?\"darwin\":" & osMod & m.captures[4] & verVar & m.captures[6]
   )
   if count5 >= 1:
     echo &"  [OK] HTTP header platform spoof: {count5} match(es)"
@@ -227,18 +203,15 @@ proc apply*(input: string): string =
   # Patch 5b: Spoof User-Agent header
   let uaPattern = re"(let )([\w$]+)(=)([\w$]+)(;)([\w$]+\.set\(""user-agent"",)\2(\))"
   var count5b = 0
-  result = result.replace(
-    uaPattern,
-    proc(m: RegexMatch): string =
-      inc count5b
-      if count5b > 1:
-        return m.match
-      let varName = m.captures[1]
-      let orig = m.captures[3]
-      m.captures[0] & varName & m.captures[2] & orig & m.captures[4] &
-        "if(process.platform===\"linux\"){" & varName & "=" & varName &
-        ".replace(/X11; Linux [^)]+/g,\"Macintosh; Intel Mac OS X 10_15_7\")}" &
-        m.captures[5] & varName & m.captures[6],
+  result = result.replace(uaPattern, proc(m: RegexMatch): string =
+    inc count5b
+    if count5b > 1: return m.match
+    let varName = m.captures[1]
+    let orig = m.captures[3]
+    m.captures[0] & varName & m.captures[2] & orig & m.captures[4] &
+      "if(process.platform===\"linux\"){" & varName & "=" & varName &
+      ".replace(/X11; Linux [^)]+/g,\"Macintosh; Intel Mac OS X 10_15_7\")}" &
+      m.captures[5] & varName & m.captures[6]
   )
   if count5b >= 1:
     echo &"  [OK] User-Agent header spoof: {count5b} match(es)"
@@ -251,17 +224,12 @@ proc apply*(input: string): string =
     quit(1)
 
   # Patch 6: Spoof platform in getSystemInfo IPC response
-  let sysinfoPattern =
-    re"(platform:)process\.platform(,arch:process\.arch,total_memory:[\w$]+\.totalmem\(\))"
+  let sysinfoPattern = re"(platform:)process\.platform(,arch:process\.arch,total_memory:[\w$]+\.totalmem\(\))"
   var count6 = 0
-  result = result.replace(
-    sysinfoPattern,
-    proc(m: RegexMatch): string =
-      inc count6
-      if count6 > 1:
-        return m.match
-      m.captures[0] & "(process.platform===\"linux\"?\"win32\":process.platform)" &
-        m.captures[1],
+  result = result.replace(sysinfoPattern, proc(m: RegexMatch): string =
+    inc count6
+    if count6 > 1: return m.match
+    m.captures[0] & "(process.platform===\"linux\"?\"win32\":process.platform)" & m.captures[1]
   )
   if count6 >= 1:
     echo &"  [OK] getSystemInfo platform spoof: {count6} match(es)"
@@ -300,7 +268,7 @@ when isMainModule:
 
   # Patch 7: Spoof window.process.platform in mainView.js preload
   let mainviewPath = filePath.parentDir / "mainView.js"
-  var patchesApplied = EXPECTED_PATCHES - 2 # patches 1-6 + 3b + 4 = 9 so far
+  var patchesApplied = EXPECTED_PATCHES - 2  # patches 1-6 + 3b + 4 = 9 so far
 
   # Count patches from apply (we need to recalculate since apply already counted them)
   # Just handle patches 7 and 8 here
@@ -309,18 +277,13 @@ when isMainModule:
     var mvContent = readFile(mainviewPath)
     let mvOriginal = mvContent
 
-    let mvPattern =
-      re"(Object\.fromEntries\(Object\.entries\(process\)\.filter\(\(\[[\w$]+\]\)=>[\w$]+\[[\w$]+\]\)\);)([\w$]+)(\.version=[\w$]+\(\)\.appVersion;)"
+    let mvPattern = re"(Object\.fromEntries\(Object\.entries\(process\)\.filter\(\(\[[\w$]+\]\)=>[\w$]+\[[\w$]+\]\)\);)([\w$]+)(\.version=[\w$]+\(\)\.appVersion;)"
     var mvCount = 0
-    mvContent = mvContent.replace(
-      mvPattern,
-      proc(m: RegexMatch): string =
-        inc mvCount
-        if mvCount > 1:
-          return m.match
-        let procVar = m.captures[1]
-        m.captures[0] & procVar & m.captures[2] & "if(process.platform===\"linux\"){" &
-          procVar & ".platform=\"win32\"}",
+    mvContent = mvContent.replace(mvPattern, proc(m: RegexMatch): string =
+      inc mvCount
+      if mvCount > 1: return m.match
+      let procVar = m.captures[1]
+      m.captures[0] & procVar & m.captures[2] & "if(process.platform===\"linux\"){" & procVar & ".platform=\"win32\"}"
     )
     if mvCount >= 1:
       echo &"  [OK] mainView.js: window.process.platform spoof ({mvCount} match)"
@@ -349,14 +312,16 @@ when isMainModule:
     patchesApplied += 1
   else:
     let navSpoofJs =
-      "if(process.platform===\"linux\"){" & "const __nav_spoof_applied=!0;" &
+      "if(process.platform===\"linux\"){" &
+      "const __nav_spoof_applied=!0;" &
       "const __oUA=require(\"electron\").app.userAgentFallback||\"\";" &
       "require(\"electron\").app.userAgentFallback=" &
       "__oUA.replace(/X11; Linux [^)]+/g,\"Windows NT 10.0; Win64; x64\");" &
       "const __navJS=\"try{Object.defineProperty(navigator,\\\"platform\\\",{get:()=>\\\"Win32\\\",configurable:!0})}catch(e){}\";" &
       "require(\"electron\").app.on(\"web-contents-created\",(ev,wc)=>{" &
       "wc.on(\"did-navigate\",()=>{wc.executeJavaScript(__navJS).catch(()=>{})});" &
-      "wc.on(\"dom-ready\",()=>{wc.executeJavaScript(__navJS).catch(()=>{})})" & "})" &
+      "wc.on(\"dom-ready\",()=>{wc.executeJavaScript(__navJS).catch(()=>{})})" &
+      "})" &
       "}"
     let strictPrefix = "\"use strict\";"
     if content.startsWith(strictPrefix):
@@ -369,7 +334,7 @@ when isMainModule:
       quit(1)
 
   # Strictness check
-  if patchesApplied < 2: # patches 7 and 8
+  if patchesApplied < 2:  # patches 7 and 8
     echo &"  [FAIL] Only {patchesApplied}/2 mainModule patches applied"
     quit(1)
 

--- a/patches/fix_asar_workspace_cwd.nim
+++ b/patches/fix_asar_workspace_cwd.nim
@@ -8,9 +8,7 @@ import regex
 
 const EXPECTED_PATCHES = 5
 
-proc replaceFirst(
-    content: var string, pattern: Regex2, subFn: proc(m: RegexMatch2, s: string): string
-): int =
+proc replaceFirst(content: var string, pattern: Regex2, subFn: proc(m: RegexMatch2, s: string): string): int =
   var found = false
   var resultStr = ""
   var lastEnd = 0
@@ -39,8 +37,7 @@ proc apply*(input: string): string =
   var patchesApplied = 0
 
   # 1. Inject helper function
-  const SANITIZE_FN =
-    "var __cdb_sanitizeCwd=function(p){if(process.platform===\"linux\"&&typeof p===\"string\"&&/app\\.asar/.test(p)){return require(\"os\").homedir()}return p};"
+  const SANITIZE_FN = "var __cdb_sanitizeCwd=function(p){if(process.platform===\"linux\"&&typeof p===\"string\"&&/app\\.asar/.test(p)){return require(\"os\").homedir()}return p};"
 
   let useStrict = "\"use strict\";"
   let idx = result.find(useStrict)
@@ -53,13 +50,11 @@ proc apply*(input: string): string =
     echo "  [OK] Injected __cdb_sanitizeCwd helper (at file start)"
 
   # 2. Patch checkTrust bridge
-  let patCt = re2"(checkTrust\()([\w$]+)(\)\{)(return [\w$]+\.info\()"
-  var countCt = result.replaceFirst(
-    patCt,
-    proc(m: RegexMatch2, s: string): string =
-      let arg = s[m.group(1)]
-      s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");" &
-        s[m.group(3)],
+  # v1.4758+: function body now starts with `const o=DQ(s);` before return N.info(...)
+  let patCt = re2"(checkTrust\()([\w$]+)(\)\{)(const [\w$]+=[\w$]+\([\w$]+\);return [\w$]+\.info\()"
+  var countCt = result.replaceFirst(patCt, proc(m: RegexMatch2, s: string): string =
+    let arg = s[m.group(1)]
+    s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");" & s[m.group(3)]
   )
   if countCt > 0:
     patchesApplied += countCt
@@ -68,13 +63,11 @@ proc apply*(input: string): string =
     echo "  [WARN] checkTrust bridge: 0 matches"
 
   # 3. Patch saveTrust bridge
-  let patSt = re2"(async saveTrust\()([\w$]+)(\)\{)([\w$]+\.info\()"
-  var countSt = result.replaceFirst(
-    patSt,
-    proc(m: RegexMatch2, s: string): string =
-      let arg = s[m.group(1)]
-      s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");" &
-        s[m.group(3)],
+  # v1.4758+: function body now starts with `const o=DQ(s);` before N.info(...)
+  let patSt = re2"(async saveTrust\()([\w$]+)(\)\{)(const [\w$]+=[\w$]+\([\w$]+\);[\w$]+\.info\()"
+  var countSt = result.replaceFirst(patSt, proc(m: RegexMatch2, s: string): string =
+    let arg = s[m.group(1)]
+    s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");" & s[m.group(3)]
   )
   if countSt > 0:
     patchesApplied += countSt
@@ -83,14 +76,10 @@ proc apply*(input: string): string =
     echo "  [WARN] saveTrust bridge: 0 matches"
 
   # 4. Patch start bridge
-  let patStart =
-    re2"(async start\()([\w$]+)(\)\{)(return [\w$]+\.info\(""LocalSessions\.start:""\))"
-  var countStart = result.replaceFirst(
-    patStart,
-    proc(m: RegexMatch2, s: string): string =
-      let arg = s[m.group(1)]
-      s[m.group(0)] & arg & s[m.group(2)] & arg & ".cwd=__cdb_sanitizeCwd(" & arg &
-        ".cwd);" & s[m.group(3)],
+  let patStart = re2"(async start\()([\w$]+)(\)\{)(return [\w$]+\.info\(""LocalSessions\.start:""\))"
+  var countStart = result.replaceFirst(patStart, proc(m: RegexMatch2, s: string): string =
+    let arg = s[m.group(1)]
+    s[m.group(0)] & arg & s[m.group(2)] & arg & ".cwd=__cdb_sanitizeCwd(" & arg & ".cwd);" & s[m.group(3)]
   )
   if countStart > 0:
     patchesApplied += countStart
@@ -99,15 +88,12 @@ proc apply*(input: string): string =
     echo "  [WARN] start bridge: 0 matches"
 
   # 5. Patch startCodeSession bridges (conditional ternary form)
-  let patScs =
-    re2"(startCodeSession:[\w$]+\?async\()([\w$]+)(,[\w$]+,[\w$]+,[\w$]+\)=>\{)"
+  let patScs = re2"(startCodeSession:[\w$]+\?async\()([\w$]+)(,[\w$]+,[\w$]+,[\w$]+\)=>\{)"
   var countScs = 0
-  result = result.replace(
-    patScs,
-    proc(m: RegexMatch2, s: string): string =
-      inc countScs
-      let arg = s[m.group(1)]
-      s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");",
+  result = result.replace(patScs, proc(m: RegexMatch2, s: string): string =
+    inc countScs
+    let arg = s[m.group(1)]
+    s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");"
   )
   if countScs > 0:
     patchesApplied += countScs
@@ -118,12 +104,10 @@ proc apply*(input: string): string =
   # Also patch the dispatch startCodeSession (different signature)
   let patScs2 = re2"(startCodeSession:async\()([\w$]+)(,[\w$]+,[\w$]+,[\w$]+\)=>\{)"
   var countScs2 = 0
-  result = result.replace(
-    patScs2,
-    proc(m: RegexMatch2, s: string): string =
-      inc countScs2
-      let arg = s[m.group(1)]
-      s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");",
+  result = result.replace(patScs2, proc(m: RegexMatch2, s: string): string =
+    inc countScs2
+    let arg = s[m.group(1)]
+    s[m.group(0)] & arg & s[m.group(2)] & arg & "=__cdb_sanitizeCwd(" & arg & ");"
   )
   if countScs2 > 0:
     patchesApplied += countScs2
@@ -132,10 +116,7 @@ proc apply*(input: string): string =
     echo "  [WARN] dispatch startCodeSession: 0 matches"
 
   if patchesApplied < EXPECTED_PATCHES:
-    raise newException(
-      ValueError,
-      &"fix_asar_workspace_cwd: Only {patchesApplied}/{EXPECTED_PATCHES} patches applied",
-    )
+    raise newException(ValueError, &"fix_asar_workspace_cwd: Only {patchesApplied}/{EXPECTED_PATCHES} patches applied")
 
 when isMainModule:
   if paramCount() != 1:

--- a/patches/fix_computer_use_linux.nim
+++ b/patches/fix_computer_use_linux.nim
@@ -38,13 +38,10 @@ proc apply*(input: string): string =
   # Patch 1: Inject Linux executor at app.on("ready")
   let readyPattern = re"""app\.on\("ready",async\(\)=>\{"""
   var count1 = 0
-  result = result.replace(
-    readyPattern,
-    proc(m: RegexMatch): string =
-      inc count1
-      if count1 > 1:
-        return m.match
-      m.match & "if(process.platform===\"linux\"){" & LINUX_EXECUTOR_JS & "}",
+  result = result.replace(readyPattern, proc(m: RegexMatch): string =
+    inc count1
+    if count1 > 1: return m.match
+    m.match & "if(process.platform===\"linux\"){" & LINUX_EXECUTOR_JS & "}"
   )
   if count1 >= 1:
     echo &"  [OK] Linux executor: injected ({count1} match)"
@@ -73,18 +70,13 @@ proc apply*(input: string): string =
       quit(1)
 
   # Patch 4: Patch createDarwinExecutor to return Linux executor on Linux
-  let executorPattern =
-    re"""(function [\w$]+\([\w$]+\)\{)if\(process\.platform!=="darwin"\)throw new Error"""
+  let executorPattern = re"""(function [\w$]+\([\w$]+\)\{)if\(process\.platform!=="darwin"\)throw new Error"""
   var count4 = 0
-  result = result.replace(
-    executorPattern,
-    proc(m: RegexMatch): string =
-      inc count4
-      if count4 > 1:
-        return m.match
-      m.captures[0] &
-        "if(process.platform===\"linux\"&&globalThis.__linuxExecutor)return globalThis.__linuxExecutor;" &
-        "if(process.platform!==\"darwin\")throw new Error",
+  result = result.replace(executorPattern, proc(m: RegexMatch): string =
+    inc count4
+    if count4 > 1: return m.match
+    m.captures[0] & "if(process.platform===\"linux\"&&globalThis.__linuxExecutor)return globalThis.__linuxExecutor;" &
+      "if(process.platform!==\"darwin\")throw new Error"
   )
   if count4 >= 1:
     echo &"  [OK] createDarwinExecutor: Linux fallback ({count4} match)"
@@ -97,15 +89,11 @@ proc apply*(input: string): string =
   # Patch 5: Patch ensureOsPermissions to return granted:true on Linux
   let permsPattern = re"ensureOsPermissions:([\w$]+)"
   var count5 = 0
-  result = result.replace(
-    permsPattern,
-    proc(m: RegexMatch): string =
-      inc count5
-      if count5 > 1:
-        return m.match
-      let fnName = m.captures[0]
-      "ensureOsPermissions:process.platform===\"linux\"?async()=>({granted:!0}):" &
-        fnName,
+  result = result.replace(permsPattern, proc(m: RegexMatch): string =
+    inc count5
+    if count5 > 1: return m.match
+    let fnName = m.captures[0]
+    "ensureOsPermissions:process.platform===\"linux\"?async()=>({granted:!0}):" & fnName
   )
   if count5 >= 1:
     echo &"  [OK] ensureOsPermissions: skip TCC on Linux ({count5} match)"
@@ -116,8 +104,7 @@ proc apply*(input: string): string =
 
   # Patch 6: Hybrid handleToolCall -- inject early-return block
   # Step A: Match the handleToolCall start
-  let htcStart =
-    re"(([\w$]+)=\{isEnabled:[\w$]+=>[\w$]+\(\),handleToolCall:async\(([\w$]+),([\w$]+),([\w$]+)\)=>\{)"
+  let htcStart = re"(([\w$]+)=\{isEnabled:[\w$]+=>[\w$]+\(\),handleToolCall:async\(([\w$]+),([\w$]+),([\w$]+)\)=>\{)"
   let htcMatch = result.find(htcStart)
 
   if htcMatch.isSome:
@@ -126,12 +113,11 @@ proc apply*(input: string): string =
     let toolNameParam = m.captures[2]
     let inputParam = m.captures[3]
     let sessionParam = m.captures[4]
-    let injectPos = m.matchBounds.b + 1 # right after the opening {
+    let injectPos = m.matchBounds.b + 1  # right after the opening {
 
     # Step B: Find the dispatcher function name
     let afterBrace = result[injectPos .. min(injectPos + 2000, result.len - 1)]
-    let dispatcherSearch =
-      re("const [\\w$]+=([\\w$]+)\\(" & sessionParam & "\\),\\{save_to_disk:")
+    let dispatcherSearch = re("const [\\w$]+=([\\w$]+)\\(" & sessionParam & "\\),\\{save_to_disk:")
     let dispatcherMatch = afterBrace.find(dispatcherSearch)
 
     if dispatcherMatch.isSome:
@@ -153,26 +139,22 @@ proc apply*(input: string): string =
     echo "  [FAIL] handleToolCall pattern: 0 matches"
     quit(1)
 
-  # Patch 7: Teach overlay controller init on Linux
-  let stubEnd = re"listInstalledApps:\(\)=>\[\]\}\)"
-  let stubMatch = result.find(stubEnd)
-  if stubMatch.isSome:
-    let afterStub = result[
-      stubMatch.get().matchBounds.b + 1 ..
-        min(stubMatch.get().matchBounds.b + 50, result.len - 1)
-    ]
-    if ".has(process.platform)" in afterStub or
-        afterStub.find(re",[\w$]+\(\)&&\(").isSome:
-      echo "  [OK] teach overlay controller: CU gate found (handled by Set fix)"
-      inc patchesApplied
-    else:
-      echo "  [FAIL] teach overlay: CU gate not found after TCC stub"
+  # Patch 7: Verify CU gate (Set-based platform check) is still present.
+  # This is a verification, not a mutation -- Patch 2 extends the Set to include
+  # "linux", which makes the gate function return true on Linux.
+  # We confirm the gate still uses .has(process.platform) globally; the old
+  # 50-char proximity check to the TCC stub was too narrow and broke when
+  # upstream inserted additional setImplementation() calls between the stub
+  # and the CU-gate consumer.
+  if ".has(process.platform)" in result:
+    echo "  [OK] teach overlay controller: CU gate found (handled by Set fix)"
+    inc patchesApplied
   else:
-    echo "  [FAIL] teach overlay: TCC stub pattern not found"
+    echo "  [FAIL] teach overlay: CU gate (.has(process.platform)) not found"
+    quit(1)
 
   # Patch 8: Fix teach overlay mouse events on Linux
-  let overlayVarPattern =
-    re"""([\w$]+)\.setAlwaysOnTop\(!0,"screen-saver"\),\1\.setFullScreenable\(!1\),\1\.setIgnoreMouseEvents\(!0,\{forward:!0\}\)"""
+  let overlayVarPattern = re"""([\w$]+)\.setAlwaysOnTop\(!0,"screen-saver"\),\1\.setFullScreenable\(!1\),\1\.setIgnoreMouseEvents\(!0,\{forward:!0\}\)"""
   let overlayVarMatch = result.find(overlayVarPattern)
   var overlayVar = ""
 
@@ -180,9 +162,10 @@ proc apply*(input: string): string =
     overlayVar = overlayVarMatch.get().captures[0]
     let oldInit = overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0})"
     let newInit =
-      "(process.platform===\"linux\"?" & "(" & overlayVar &
-      ".setIgnoreMouseEvents=function(){}," & "globalThis.__isVM&&" & overlayVar &
-      ".setOpacity(.15))" & ":" & overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0}))"
+      "(process.platform===\"linux\"?" &
+      "(" & overlayVar & ".setIgnoreMouseEvents=function(){}," &
+      "globalThis.__isVM&&" & overlayVar & ".setOpacity(.15))" &
+      ":" & overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0}))"
 
     let idx = result.find(oldInit)
     if idx >= 0:
@@ -197,19 +180,15 @@ proc apply*(input: string): string =
 
   # Patch 9a: Neutralize setIgnoreMouseEvents in yJt
   if overlayVar != "":
-    let yjtPat =
-      re"(function [\w$]+\([\w$]+,[\w$]+\)\{)([\w$]+)(\.setIgnoreMouseEvents\(!0,\{forward:!0\}\))"
+    let yjtPat = re"(function [\w$]+\([\w$]+,[\w$]+\)\{)([\w$]+)(\.setIgnoreMouseEvents\(!0,\{forward:!0\}\))"
     var yjtCount = 0
-    result = result.replace(
-      yjtPat,
-      proc(m: RegexMatch): string =
-        inc yjtCount
-        if yjtCount > 1:
-          return m.match
-        let fnHead = m.captures[0]
-        let varName = m.captures[1]
-        let rest = m.captures[2]
-        fnHead & "(process.platform!==\"linux\"&&" & varName & rest & ")",
+    result = result.replace(yjtPat, proc(m: RegexMatch): string =
+      inc yjtCount
+      if yjtCount > 1: return m.match
+      let fnHead = m.captures[0]
+      let varName = m.captures[1]
+      let rest = m.captures[2]
+      fnHead & "(process.platform!==\"linux\"&&" & varName & rest & ")"
     )
     if yjtCount >= 1:
       echo "  [OK] teach overlay: neutralized setIgnoreMouseEvents in show handler (yJt) for Linux"
@@ -219,13 +198,8 @@ proc apply*(input: string): string =
       echo "  [FAIL] teach overlay: yJt pattern not found"
 
     # Patch 9b: Neutralize setIgnoreMouseEvents in SUn
-    let sunPat =
-      overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0})," & overlayVar &
-      ".webContents.send(\"cu-teach:working\""
-    let sunRepl =
-      "(process.platform!==\"linux\"&&" & overlayVar &
-      ".setIgnoreMouseEvents(!0,{forward:!0}))," & overlayVar &
-      ".webContents.send(\"cu-teach:working\""
+    let sunPat = overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0})," & overlayVar & ".webContents.send(\"cu-teach:working\""
+    let sunRepl = "(process.platform!==\"linux\"&&" & overlayVar & ".setIgnoreMouseEvents(!0,{forward:!0}))," & overlayVar & ".webContents.send(\"cu-teach:working\""
     if sunPat in result:
       result = result.replace(sunPat, sunRepl)
       echo "  [OK] teach overlay: neutralized setIgnoreMouseEvents in working handler (SUn) for Linux"
@@ -235,23 +209,18 @@ proc apply*(input: string): string =
       echo "  [FAIL] teach overlay: SUn pattern not found"
 
   # Patch 10: Fix teach overlay transparency on VMs
-  let teachOverlayPattern =
-    re"(=new [\w$]+\.BrowserWindow\(\{[^}]*?)transparent:!0([^}]*?)backgroundColor:""#00000000"""
+  let teachOverlayPattern = re"(=new [\w$]+\.BrowserWindow\(\{[^}]*?)transparent:!0([^}]*?)backgroundColor:""#00000000"""
   var pos10 = 0
   var found10 = false
   while true:
     let m = result.find(teachOverlayPattern, pos10)
-    if m.isNone:
-      break
+    if m.isNone: break
     let bounds = m.get().matchBounds
     let before = result[max(0, bounds.a - 80) ..< bounds.a]
     if "workArea" in before:
       let old = m.get().match
       var newStr = old.replace("transparent:!0", "transparent:!globalThis.__isVM")
-      newStr = newStr.replace(
-        "backgroundColor:\"#00000000\"",
-        "backgroundColor:globalThis.__isVM?\"#000000\":\"#00000000\"",
-      )
+      newStr = newStr.replace("backgroundColor:\"#00000000\"", "backgroundColor:globalThis.__isVM?\"#000000\":\"#00000000\"")
       result = result.replace(old, newStr)
       echo "  [OK] teach overlay: VM-aware transparency (transparent on native, dark backdrop on VMs)"
       changes += 1
@@ -263,18 +232,13 @@ proc apply*(input: string): string =
     echo "  [FAIL] teach overlay transparency pattern not found"
 
   # Patch 10b: Force teach overlay display to primary monitor on Linux
-  let xlrPattern =
-    re"(function [\w$]+\(([\w$]+)\)\{)(return \2===null\?[\w$]+\.screen\.getPrimaryDisplay\(\):[\w$]+\.screen\.getAllDisplays\(\)\.find)"
+  let xlrPattern = re"(function [\w$]+\(([\w$]+)\)\{)(return \2===null\?[\w$]+\.screen\.getPrimaryDisplay\(\):[\w$]+\.screen\.getAllDisplays\(\)\.find)"
   var count10b = 0
-  result = result.replace(
-    xlrPattern,
-    proc(m: RegexMatch): string =
-      inc count10b
-      if count10b > 1:
-        return m.match
-      let param = m.captures[1]
-      m.captures[0] & "if(process.platform===\"linux\")" & param & "=null;" &
-        m.captures[2],
+  result = result.replace(xlrPattern, proc(m: RegexMatch): string =
+    inc count10b
+    if count10b > 1: return m.match
+    let param = m.captures[1]
+    m.captures[0] & "if(process.platform===\"linux\")" & param & "=null;" & m.captures[2]
   )
   if count10b >= 1:
     echo &"  [OK] teach overlay display: forced to primary monitor on Linux ({count10b} match)"
@@ -284,17 +248,13 @@ proc apply*(input: string): string =
     echo "  [FAIL] xlr display resolver pattern: 0 matches"
 
   # Patch 11: Force mVt() isEnabled to return true on Linux
-  let mVtPattern =
-    re"(function [\w$]+\(\)\{)return [\w$]+\([\w$]+\)\?[\w$]+\.has\(process\.platform\)&&[\w$]+\(\):[\w$]+\(\)\}"
+  let mVtPattern = re"(function [\w$]+\(\)\{)return [\w$]+\([\w$]+\)\?[\w$]+\.has\(process\.platform\)&&[\w$]+\(\):[\w$]+\(\)\}"
   var count11 = 0
-  result = result.replace(
-    mVtPattern,
-    proc(m: RegexMatch): string =
-      inc count11
-      if count11 > 1:
-        return m.match
-      m.captures[0] & "if(process.platform===\"linux\")return!0;" &
-        m.match[m.captures[0].len .. ^1],
+  result = result.replace(mVtPattern, proc(m: RegexMatch): string =
+    inc count11
+    if count11 > 1: return m.match
+    m.captures[0] & "if(process.platform===\"linux\")return!0;" &
+      m.match[m.captures[0].len .. ^1]
   )
   if count11 >= 1:
     echo &"  [OK] mVt isEnabled: force true on Linux ({count11} match)"
@@ -304,17 +264,13 @@ proc apply*(input: string): string =
     echo "  [FAIL] mVt isEnabled pattern: 0 matches"
 
   # Patch 12: Force rj() to return true on Linux
-  let rjPattern =
-    re"""(function [\w$]+\(\)\{)return [\w$]+\.has\(process\.platform\)\?[\w$]+\(\)&&[\w$]+\("chicagoEnabled"\):!1\}"""
+  let rjPattern = re"""(function [\w$]+\(\)\{)return [\w$]+\.has\(process\.platform\)\?[\w$]+\(\)&&[\w$]+\("chicagoEnabled"\):!1\}"""
   var count12 = 0
-  result = result.replace(
-    rjPattern,
-    proc(m: RegexMatch): string =
-      inc count12
-      if count12 > 1:
-        return m.match
-      m.captures[0] & "if(process.platform===\"linux\")return!0;" &
-        m.match[m.captures[0].len .. ^1],
+  result = result.replace(rjPattern, proc(m: RegexMatch): string =
+    inc count12
+    if count12 > 1: return m.match
+    m.captures[0] & "if(process.platform===\"linux\")return!0;" &
+      m.match[m.captures[0].len .. ^1]
   )
   if count12 >= 1:
     echo &"  [OK] rj chicagoEnabled bypass: force true on Linux ({count12} match)"
@@ -328,19 +284,13 @@ proc apply*(input: string): string =
   var descChanges = 0
 
   # 13a: Lf allowlist gate warning -- empty on Linux
-  let lfPat = re(
-    "([\\w$]+)=\"The frontmost application must be in the session allowlist at the time of this call, or this tool returns an error and does nothing\\.\""
-  )
+  let lfPat = re("([\\w$]+)=\"The frontmost application must be in the session allowlist at the time of this call, or this tool returns an error and does nothing\\.\"")
   var countLf = 0
-  result = result.replace(
-    lfPat,
-    proc(m: RegexMatch): string =
-      inc countLf
-      if countLf > 1:
-        return m.match
-      let v = m.captures[0]
-      v &
-        "=process.platform===\"linux\"?\"\":\"The frontmost application must be in the session allowlist at the time of this call, or this tool returns an error and does nothing.\"",
+  result = result.replace(lfPat, proc(m: RegexMatch): string =
+    inc countLf
+    if countLf > 1: return m.match
+    let v = m.captures[0]
+    v & "=process.platform===\"linux\"?\"\":\"The frontmost application must be in the session allowlist at the time of this call, or this tool returns an error and does nothing.\""
   )
   if countLf >= 1:
     echo "  [OK] 13a Lf allowlist gate: empty on Linux"
@@ -351,14 +301,15 @@ proc apply*(input: string): string =
 
   # 13b: request_access -- "Linux" instead of "macOS"/"Finder"
   let old13b = "'This computer is running macOS. The file manager is \"Finder\". '"
-  let new13b =
-    "(e.platform===\"linux\"?" & "'This computer is running Linux. " &
+  let new13b = "(e.platform===\"linux\"?" &
+    "'This computer is running Linux. " &
     "On Linux, ALL applications are automatically accessible at full " &
     "tier without explicit permission grants. You do NOT need to call " &
     "request_access before using other tools. If called, it returns " &
     "synthetic grant confirmations. The file manager depends on the " &
     "desktop environment (e.g. Nautilus on GNOME, Dolphin on KDE, " &
-    "Thunar on XFCE). '" & ":" &
+    "Thunar on XFCE). '" &
+    ":" &
     "'This computer is running macOS. The file manager is \"Finder\". ')"
   if old13b in result:
     result = result.replace(old13b, new13b)
@@ -369,13 +320,12 @@ proc apply*(input: string): string =
     echo "  [FAIL] 13b request_access macOS prefix: not found"
 
   # 13c: App identifier (request_access apps schema)
-  let old13c =
-    "'Application display names (e.g. \"Slack\", \"Calendar\") or bundle identifiers (e.g. \"com.tinyspeck.slackmacgap\"). Display names are resolved case-insensitively against installed apps.'"
-  let new13c =
-    "(e.platform===\"linux\"?" &
+  let old13c = "'Application display names (e.g. \"Slack\", \"Calendar\") or bundle identifiers (e.g. \"com.tinyspeck.slackmacgap\"). Display names are resolved case-insensitively against installed apps.'"
+  let new13c = "(e.platform===\"linux\"?" &
     "'Application names as shown in window titles, or WM_CLASS values " &
     "(e.g. \"firefox\", \"org.gnome.Nautilus\"). " &
-    "On Linux all apps are auto-granted at full tier.'" & ":" &
+    "On Linux all apps are auto-granted at full tier.'" &
+    ":" &
     "'Application display names (e.g. \"Slack\", \"Calendar\") or bundle " &
     "identifiers (e.g. \"com.tinyspeck.slackmacgap\"). Display names are " &
     "resolved case-insensitively against installed apps.')"
@@ -388,11 +338,10 @@ proc apply*(input: string): string =
     echo "  [FAIL] 13c request_access apps: not found"
 
   # 13d: open_application app identifier
-  let old13d =
-    "'Display name (e.g. \"Slack\") or bundle identifier (e.g. \"com.tinyspeck.slackmacgap\").'"
-  let new13d =
-    "(e.platform===\"linux\"?" &
-    "'Application name or WM_CLASS (e.g. \"firefox\", \"nautilus\").'" & ":" &
+  let old13d = "'Display name (e.g. \"Slack\") or bundle identifier (e.g. \"com.tinyspeck.slackmacgap\").'"
+  let new13d = "(e.platform===\"linux\"?" &
+    "'Application name or WM_CLASS (e.g. \"firefox\", \"nautilus\").'" &
+    ":" &
     "'Display name (e.g. \"Slack\") or bundle identifier (e.g. \"com.tinyspeck.slackmacgap\").')"
   if old13d in result:
     result = result.replace(old13d, new13d)
@@ -403,12 +352,11 @@ proc apply*(input: string): string =
     echo "  [FAIL] 13d open_application app: not found"
 
   # 13e: open_application -- no allowlist on Linux
-  let old13e =
-    "\"Bring an application to the front, launching it if necessary. The target application must already be in the session allowlist \xe2\x80\x94 call request_access first.\""
-  let new13e =
-    "(process.platform===\"linux\"?" &
+  let old13e = "\"Bring an application to the front, launching it if necessary. The target application must already be in the session allowlist \xe2\x80\x94 call request_access first.\""
+  let new13e = "(process.platform===\"linux\"?" &
     "\"Bring an application to the front, launching it if necessary. " &
-    "On Linux, all applications are directly accessible.\"" & ":" &
+    "On Linux, all applications are directly accessible.\"" &
+    ":" &
     "\"Bring an application to the front, launching it if necessary. " &
     "The target application must already be in the session allowlist " &
     "\xe2\x80\x94 call request_access first.\")"
@@ -421,13 +369,13 @@ proc apply*(input: string): string =
     echo "  [FAIL] 13e open_application: not found"
 
   # 13f: screenshot (none-filtering)
-  let old13f =
-    "\"Take a screenshot of the primary display. On this platform, " &
+  let old13f = "\"Take a screenshot of the primary display. On this platform, " &
     "screenshots are NOT filtered \xe2\x80\x94 all open windows are visible. " &
     "Input actions targeting apps not in the session allowlist are rejected.\""
-  let new13f =
-    "(process.platform===\"linux\"?" & "\"Take a screenshot of the primary display. " &
-    "All open windows are visible.\"" & ":" &
+  let new13f = "(process.platform===\"linux\"?" &
+    "\"Take a screenshot of the primary display. " &
+    "All open windows are visible.\"" &
+    ":" &
     "\"Take a screenshot of the primary display. On this platform, " &
     "screenshots are NOT filtered \xe2\x80\x94 all open windows are visible. " &
     "Input actions targeting apps not in the session allowlist are rejected.\")"
@@ -440,20 +388,15 @@ proc apply*(input: string): string =
     echo "  [FAIL] 13f screenshot: not found"
 
   # 13g: screenshot suffix
-  let ssSfxPat = re(
-    "([\\w$]+)\\+\" Returns an error if the allowlist is empty\\. The returned image is what subsequent click coordinates are relative to\\.\""
-  )
+  let ssSfxPat = re("([\\w$]+)\\+\" Returns an error if the allowlist is empty\\. The returned image is what subsequent click coordinates are relative to\\.\"")
   var countSfx = 0
-  result = result.replace(
-    ssSfxPat,
-    proc(m: RegexMatch): string =
-      inc countSfx
-      if countSfx > 1:
-        return m.match
-      let v = m.captures[0]
-      v & "+(process.platform===\"linux\"" &
-        "?\" The returned image is what subsequent click coordinates are relative to.\"" &
-        ":\" Returns an error if the allowlist is empty. The returned image is what subsequent click coordinates are relative to.\")",
+  result = result.replace(ssSfxPat, proc(m: RegexMatch): string =
+    inc countSfx
+    if countSfx > 1: return m.match
+    let v = m.captures[0]
+    v & "+(process.platform===\"linux\"" &
+      "?\" The returned image is what subsequent click coordinates are relative to.\"" &
+      ":\" Returns an error if the allowlist is empty. The returned image is what subsequent click coordinates are relative to.\")"
   )
   if countSfx >= 1:
     echo "  [OK] 13g screenshot suffix: no allowlist error on Linux"
@@ -472,12 +415,10 @@ proc apply*(input: string): string =
 
   # 14a: Replace "Separate filesystems" paragraph (2 occurrences)
   # Uses UTF-8 em-dash: \xe2\x80\x94
-  let sepOldFull =
-    "**Separate filesystems.** Computer-use actions (clicks, typing, clipboard writes) happen on the user\x27s real computer \xe2\x80\x94 a different system from your sandbox. "
+  let sepOldFull = "**Separate filesystems.** Computer-use actions (clicks, typing, clipboard writes) happen on the user\x27s real computer \xe2\x80\x94 a different system from your sandbox. "
   let sepCount = result.count(sepOldFull)
   if sepCount >= 2:
-    let sepNewFull =
-      "${process.platform===\"linux\"" &
+    let sepNewFull = "${process.platform===\"linux\"" &
       "?\"**Same filesystem.** Computer-use actions and your CLI tools operate on the same Linux machine. " &
       "There is no sandbox \\u2014 files you create are directly accessible to desktop applications and vice versa. \"" &
       ":\"**Separate filesystems.** Computer-use actions (clicks, typing, clipboard writes) " &
@@ -491,8 +432,7 @@ proc apply*(input: string): string =
 
   # 14b: Replace macOS app names with generic Linux terms
   let appsOld = "Maps, Notes, Finder, Photos, System Settings"
-  let appsNew =
-    "${process.platform===\"linux\"?\"the file manager, image viewer, terminal emulator, system settings\":\"Maps, Notes, Finder, Photos, System Settings\"}"
+  let appsNew = "${process.platform===\"linux\"?\"the file manager, image viewer, terminal emulator, system settings\":\"Maps, Notes, Finder, Photos, System Settings\"}"
   if appsOld in result:
     result = result.replace(appsOld, appsNew)
     echo "  [OK] 14b app names: replaced macOS apps with Linux-generic terms"

--- a/patches/fix_dock_bounce.nim
+++ b/patches/fix_dock_bounce.nim
@@ -1,15 +1,14 @@
 # @patch-target: app.asar.contents/.vite/build/index.js
 # @patch-type: nim
 # Suppress taskbar flashing (demands-attention) on Linux/Wayland+X11.
-# Four sub-patches: early monkey-patch, steal-focus, rua-guard, bg-throttle.
+# Three sub-patches: early monkey-patch, steal-focus, rua-guard.
 
 import std/[os, strformat, strutils]
 import regex
 
-const EXPECTED_PATCHES = 4
+const EXPECTED_PATCHES = 3
 
-const LINUX_WAYLAND_GUARD =
-  """;(function(){
+const LINUX_WAYLAND_GUARD = """;(function(){
 if(process.platform!=="linux")return;
 var _e=require("electron");
 
@@ -90,9 +89,7 @@ if(_t){clearInterval(_t);_t=null;}
 });
 })();"""
 
-proc replaceFirst(
-    content: var string, pattern: Regex2, subFn: proc(m: RegexMatch2, s: string): string
-): int =
+proc replaceFirst(content: var string, pattern: Regex2, subFn: proc(m: RegexMatch2, s: string): string): int =
   var found = false
   var resultStr = ""
   var lastEnd = 0
@@ -123,30 +120,25 @@ proc apply*(input: string): string =
     patchesApplied += 1
   else:
     # Remove old version of guard if present
-    let oldMarkers =
-      @[
-        "_e.app.focus=function(){}",
-        "_e.BrowserWindow.prototype.flashFrame=function(){}",
-      ]
+    let oldMarkers = @[
+      "_e.app.focus=function(){}",
+      "_e.BrowserWindow.prototype.flashFrame=function(){}",
+    ]
     for oldM in oldMarkers:
       if oldM in result and marker notin result:
         # Old guard removal via regex
-        let oldGuardPat =
-          re2";?\(function\(\)\{\s*if\(process\.platform===""linux""\)\{.*?\}\s*\}\)\(\);"
+        let oldGuardPat = re2";?\(function\(\)\{\s*if\(process\.platform===""linux""\)\{.*?\}\s*\}\)\(\);"
         var dummy = 0
-        result = result.replace(
-          oldGuardPat,
-          proc(m: RegexMatch2, s: string): string =
-            inc dummy
-            "",
+        result = result.replace(oldGuardPat, proc(m: RegexMatch2, s: string): string =
+          inc dummy
+          ""
         )
         if dummy > 0:
           echo "  [OK] Removed old monkey-patch block"
         break
 
     if result.startsWith("\"use strict\";"):
-      result =
-        "\"use strict\";" & LINUX_WAYLAND_GUARD & result[len("\"use strict\";") .. ^1]
+      result = "\"use strict\";" & LINUX_WAYLAND_GUARD & result[len("\"use strict\";") .. ^1]
       echo "  [OK] Early monkey-patch injected after \"use strict\""
       applied.add("early-guard")
       patchesApplied += 1
@@ -166,11 +158,9 @@ proc apply*(input: string): string =
     break
 
   var stealCount = 0
-  result = result.replace(
-    stealPattern,
-    proc(m: RegexMatch2, s: string): string =
-      inc stealCount
-      s[m.group(0)] & "({})",
+  result = result.replace(stealPattern, proc(m: RegexMatch2, s: string): string =
+    inc stealCount
+    s[m.group(0)] & "({})"
   )
   if stealCount > 0:
     echo &"  [OK] Removed app.focus({{steal}}) calls: {stealCount} match(es)"
@@ -189,14 +179,11 @@ proc apply*(input: string): string =
     applied.add("rua-guard(skip)")
     patchesApplied += 1
   else:
-    let ruaPattern =
-      re2"(requestUserAttention\(\)\{)(var [\w$]+;this\.isAppFocusedAndVisible\(\)\|\|)"
+    let ruaPattern = re2"(requestUserAttention\(\)\{)(var [\w$]+;this\.isAppFocusedAndVisible\(\)\|\|)"
     var ruaCount = 0
-    result = result.replace(
-      ruaPattern,
-      proc(m: RegexMatch2, s: string): string =
-        inc ruaCount
-        s[m.group(0)] & "if(process.platform===\"linux\")return;" & s[m.group(1)],
+    result = result.replace(ruaPattern, proc(m: RegexMatch2, s: string): string =
+      inc ruaCount
+      s[m.group(0)] & "if(process.platform===\"linux\")return;" & s[m.group(1)]
     )
     if ruaCount > 0:
       echo &"  [OK] requestUserAttention Linux guard: {ruaCount} match(es)"
@@ -205,32 +192,12 @@ proc apply*(input: string): string =
     else:
       echo "  [FAIL] requestUserAttention pattern not matched"
 
-  # 4. Enable backgroundThrottling on Linux for mainView
-  if "backgroundThrottling:process.platform!==\"linux\"" in result:
-    echo "  [INFO] backgroundThrottling already patched"
-    applied.add("bg-throttle(skip)")
-    patchesApplied += 1
-  else:
-    let bgPattern = re2"(enableBlinkFeatures:void 0,backgroundThrottling):(!1)"
-    var bgCount = 0
-    result = result.replace(
-      bgPattern,
-      proc(m: RegexMatch2, s: string): string =
-        inc bgCount
-        s[m.group(0)] & ":process.platform!==\"linux\"?!1:!0",
-    )
-    if bgCount > 0:
-      echo &"  [OK] backgroundThrottling enabled on Linux: {bgCount} match(es)"
-      applied.add(&"bg-throttle({bgCount})")
-      patchesApplied += 1
-    else:
-      echo "  [FAIL] backgroundThrottling pattern not matched"
+  # Sub-patch 4 (bg-throttle) removed: backgroundThrottling was explicitly
+  # set to false by upstream but has been removed in 1.4758.0+. Electron's
+  # default is true, which is the behaviour the patch intended for Linux.
 
   if patchesApplied < EXPECTED_PATCHES:
-    raise newException(
-      ValueError,
-      &"fix_dock_bounce: Only {patchesApplied}/{EXPECTED_PATCHES} patches applied",
-    )
+    raise newException(ValueError, &"fix_dock_bounce: Only {patchesApplied}/{EXPECTED_PATCHES} patches applied")
 
 when isMainModule:
   if paramCount() != 1:

--- a/patches/fix_ion_dist_linux.nim
+++ b/patches/fix_ion_dist_linux.nim
@@ -54,18 +54,25 @@ proc apply(filePath: string): int =
   else:
     echo "  [FAIL] org-plugins linux path: pattern not found"
 
-  # Sub-patch B: Fix Ei component to use linux path when on Linux
-  let oldTernary = "r===W.Win32?t.win:t.mac"
-  let newTernary = "r===W.Win32?t.win:r===W.Linux?t.linux:t.mac"
-
-  if content.contains(newTernary):
-    echo "  [OK] mount path platform ternary: already applied"
-    patchesApplied += 1
-  elif content.contains(oldTernary):
-    content = content.replace(oldTernary, newTernary)
-    echo "  [OK] mount path platform ternary: 1 match"
-    patchesApplied += 1
-  else:
+  # Sub-patch B: Fix mount-path display component to use linux path when on Linux.
+  # Platform enum variable renamed W -> G in v1.4758.0; match flexibly.
+  var foundTernary = false
+  for (old, new) in [
+    ("r===W.Win32?t.win:t.mac", "r===W.Win32?t.win:r===W.Linux?t.linux:t.mac"),
+    ("r===G.Win32?t.win:t.mac", "r===G.Win32?t.win:r===G.Linux?t.linux:t.mac"),
+  ]:
+    if content.contains(new):
+      echo "  [OK] mount path platform ternary: already applied"
+      patchesApplied += 1
+      foundTernary = true
+      break
+    elif content.contains(old):
+      content = content.replace(old, new)
+      echo "  [OK] mount path platform ternary: 1 match"
+      patchesApplied += 1
+      foundTernary = true
+      break
+  if not foundTernary:
     echo "  [FAIL] mount path platform ternary: pattern not found"
 
   if patchesApplied < EXPECTED_PATCHES:

--- a/patches/fix_locale_paths_pre.nim
+++ b/patches/fix_locale_paths_pre.nim
@@ -16,9 +16,10 @@ proc apply*(input: string): string =
     result = input.replace(oldResourcePath, newResourcePath)
     echo "  [OK] process.resourcesPath: " & $count & " match(es)"
   else:
-    echo "  [FAIL] process.resourcesPath: 0 matches, expected >= 1"
+    # Locale loading was consolidated into index.js in v1.4758.0.
+    # index.pre.js no longer contains process.resourcesPath -- this is expected.
+    echo "  [INFO] process.resourcesPath: 0 matches (locale code absent from index.pre.js, nothing to patch)"
     result = input
-    quit(1)
 
 when isMainModule:
   if paramCount() != 1:
@@ -37,4 +38,4 @@ when isMainModule:
     writeFile(filePath, output)
     echo "  [PASS] All required patterns matched and applied"
   else:
-    echo "  [WARN] No changes made (patterns may have already been applied)"
+    echo "  [INFO] No changes made (pattern absent or already applied)"


### PR DESCRIPTION
## Summary

Fixes #64

Updates 6 patch scripts that break against Claude Desktop v1.4758.0 due
to minified JS bundle changes.

## Changes

### `patches/enable_local_agent_mode.nim` — yukonSilver sub-patch
**Change:** `Qe.formatMessage` became `Qe().formatMessage` — the intl
formatter identifier is now called as a function before `.formatMessage`.
Pattern `[\w$]+\.formatMessage` no longer matched.
**Fix:** Pattern updated to `[\w$]+(?:\(\))?\.formatMessage`.

### `patches/fix_asar_workspace_cwd.nim` — checkTrust / saveTrust
**Change:** Both functions now start with a `const o=DQ(s);` statement
before the `return N.info(` / `N.info(` calls. The existing patterns
expected `N.info(` at a specific position and no longer matched.
**Fix:** Patterns updated to include the new `const o=DQ(s);` prefix.

### `patches/fix_computer_use_linux.nim` — CU gate proximity check (Patch 7)
**Change:** The distance from the TCC stub (`listInstalledApps:()=>[]})`)
to the `.has(process.platform)` gate grew from ~50 chars to ~86,000 chars.
The proximity/offset check that assumed the TCC stub immediately preceded
the gate no longer matched.
**Fix:** Replaced the proximity check with a global search for
`.has(process.platform)` in the result string.

### `patches/fix_dock_bounce.nim` — backgroundThrottling sub-patch (sub-patch 4)
**Change:** `backgroundThrottling` was removed from the upstream
`webPreferences` object entirely in v1.4758.0. Electron's default is
`true`, which is the behavior the patch intended for Linux.
**Fix:** Sub-patch 4 removed entirely; `EXPECTED_PATCHES` reduced from 4
to 3.

### `patches/fix_ion_dist_linux.nim` — mount-path display ternary
**Change:** The platform enum variable was renamed from `W` to `G`
(`r===W.Win32?t.win:t.mac` → `r===G.Win32?t.win:t.mac`).
**Fix:** The loop now tries both `W` and `G` variants, making it
forward-compatible with future renames.

### `patches/fix_locale_paths_pre.nim` — resourcesPath pattern
**Change:** `process.resourcesPath` no longer appears in `index.pre.js` —
locale resolution was consolidated into `index.js`.
**Fix:** Pattern changed from required (exit 1 on 0 matches) to optional
(`[INFO]` + continue), since `fix_locale_paths.nim` handles this in
`index.js`.

## Test Plan

- [ ] Build against Claude Desktop v1.4758.0 — all patches pass `[OK]`
- [ ] `node --check` on patched `index.js` exits 0
- [ ] Install and verify:
  - Local agent mode starts
  - Computer use teach overlay works on Linux
  - Taskbar flashing suppressed
  - Workspace CWD sanitization active

🤖 Generated with [Claude Code](https://claude.com/claude-code)