### PR TITLE
fix(marketplace): promote $HOME project-scoped plugins to user scope on Linux

### DIFF
--- a/patches/fix_marketplace_linux.nim
+++ b/patches/fix_marketplace_linux.nim
@@ -1,57 +1,63 @@
 # @patch-target: app.asar.contents/.vite/build/index.js
 # @patch-type: nim
 #
-# Force CCD mode for marketplace operations on Linux.
-#
-# The CCD/Cowork gate function determines whether plugin operations use
-# host-local CCD paths or account-scoped Cowork paths. On Linux there's
-# no VM, so all operations should use the CCD (host-local) path.
+# A: Force CCD mode on Linux (no Cowork VM available).
+# B: CLI stores personal plugins as scope="project"+projectPath=$HOME;
+#    promote those to scope="user" so the web UI shows them under
+#    "Persönliche Plugins" instead of the current project header.
 
-import std/[os, options]
+import std/[os, strformat]
 import std/nre
 
-proc apply*(input: string): string =
-  let idempotencyPattern =
-    re"""function [\w$]+\([\w$]+\)\{return process\.platform==="linux"\|\|"""
-  if input.contains(idempotencyPattern):
-    echo "  [OK] Already patched (Linux platform check found in CCD gate)"
-    echo "  [PASS] No changes needed"
-    return input
+const EXPECTED_PATCHES = 2
+var patchesApplied = 0
 
-  # CCD/Cowork gate -- force CCD mode on Linux
-  # Uses backreference \2 to ensure the param name repeats consistently
-  let pattern =
-    re"""function ([\w$]+)\(([\w$]+)\)\{return\((\2)==null\?void 0:\3\.mode\)==="ccd"\}"""
-  let m = input.find(pattern)
-  if m.isSome:
-    let match = m.get
-    let fnName = match.captures[0]
-    let param = match.captures[1]
-    let replacement =
-      "function " & fnName & "(" & param & """){return process.platform==="linux"||(""" &
-      param & "==null?void 0:" & param & """.mode)==="ccd"}"""
-    result =
-      input[0 ..< match.matchBounds.a] & replacement &
-      input[match.matchBounds.b + 1 .. ^1]
-    echo "  [OK] CCD/Cowork gate: force CCD mode on Linux (1 match)"
+proc apply*(input: string): string =
+  result = input
+
+  # A: CCD/Cowork gate
+  if result.contains(re"""function [\w$]+\([\w$]+\)\{return process\.platform==="linux"\|\|"""):
+    echo "  [SKIP] A already patched"; inc patchesApplied
   else:
-    echo "  [FAIL] CCD/Cowork gate: 0 matches"
+    let m = result.find(re"""function ([\w$]+)\(([\w$]+)\)\{return\((\2)==null\?void 0:\3\.mode\)==="ccd"\}""")
+    if m.isSome:
+      let c = m.get.captures
+      result = result[0 ..< m.get.matchBounds.a] &
+        "function " & c[0] & "(" & c[1] & "){return process.platform===\"linux\"||(" &
+        c[1] & "==null?void 0:" & c[1] & ".mode)===\"ccd\"}" &
+        result[m.get.matchBounds.b + 1 .. ^1]
+      echo "  [OK] A CCD gate (1 match)"; inc patchesApplied
+    else:
+      echo "  [FAIL] A CCD gate: 0 matches"
+
+  # B: scope normalization in getAllLocalPluginsWithResolver
+  if result.contains(re"""if\([\w$]+\.scope===\"user\"\|\|[\w$]+\.scope===\"project\"\&\&[\w$]+\.projectPath"""):
+    echo "  [SKIP] B already patched"; inc patchesApplied
+  else:
+    let m = result.find(re"""if\(([\w$]+)\.scope===\"user\"\)\{([\w$]+)\.push\(this\.entryToPluginInfo\(([\w$]+),\1,([\w$]+),([\w$]+)\)\);continue\}""")
+    if m.isSome:
+      let c = m.get.captures
+      let (e, s, o, n, i) = (c[0], c[1], c[2], c[3], c[4])
+      let homedir = e & ".scope===\"project\"&&" & e & ".projectPath&&" &
+        "require(\"path\").normalize(" & e & ".projectPath)===require(\"path\").normalize(process.env.HOME)"
+      result = result[0 ..< m.get.matchBounds.a] &
+        "if(" & e & ".scope===\"user\"||" & homedir & "){" &
+        s & ".push(this.entryToPluginInfo(" & o & ",{..." & e & ",scope:\"user\"}," & n & "," & i & "));continue}" &
+        result[m.get.matchBounds.b + 1 .. ^1]
+      echo "  [OK] B scope normalization (1 match)"; inc patchesApplied
+    else:
+      echo "  [FAIL] B scope normalization: 0 matches"
+
+  if patchesApplied < EXPECTED_PATCHES:
+    echo &"  [FAIL] Only {patchesApplied}/{EXPECTED_PATCHES} sub-patches applied"
     quit(1)
 
 when isMainModule:
-  if paramCount() != 1:
-    echo "Usage: fix_marketplace_linux <path_to_index.js>"
-    quit(1)
+  if paramCount() != 1: echo "Usage: fix_marketplace_linux <file>"; quit(1)
   let filePath = paramStr(1)
   echo "=== Patch: fix_marketplace_linux ==="
-  echo "  Target: " & filePath
-  if not fileExists(filePath):
-    echo "  [FAIL] File not found: " & filePath
-    quit(1)
+  if not fileExists(filePath): echo "  [FAIL] File not found: " & filePath; quit(1)
   let input = readFile(filePath)
   let output = apply(input)
-  if output == input:
-    echo "  [WARN] No changes made (pattern may have already been applied)"
-  else:
-    writeFile(filePath, output)
-    echo "  [PASS] Marketplace Linux patch applied"
+  if output != input: writeFile(filePath, output)
+  echo "  [PASS] Marketplace Linux patch applied"


### PR DESCRIPTION
## Problem

Personal plugins installed via the Claude Code CLI are stored as
`scope="project"` with `projectPath=$HOME` in `installed_plugins.json`.
The Desktop UI's `getAllLocalPluginsWithResolver` shows project-scoped
plugins under the matching project header. Since `$HOME` is a prefix of
every project path, CLI-installed personal plugins always appear under the
current project header instead of "Personal Plugins".

Fixes #74

## Solution

Extended `fix_marketplace_linux.nim` with a second sub-patch (B) that
normalizes scope at read time. When a plugin entry has `scope="project"` and
`projectPath` equals `$HOME`, it is promoted to `scope="user"` before being
passed to `entryToPluginInfo`. The rest of the pipeline sees a clean
user-scoped entry and renders it under "Personal Plugins".

```js
if(u.scope==="user" || (
  u.scope==="project" &&
  u.projectPath &&
  path.normalize(u.projectPath) === path.normalize(process.env.HOME)
)) {
  s.push(this.entryToPluginInfo(o, {...u, scope:"user"}, n, I));
  continue
}
```

## Why this approach

- **No CLI changes needed.** The fix lives entirely in the Desktop patch,
  which is the correct layer for a Linux-specific workaround.
- **Minimal surface area.** Only entries that are explicitly
  `scope="project"` with `projectPath=$HOME` are touched. All other entries
  (user, project with real paths, local) flow through unchanged.
- **Idempotent.** Running the patch twice is safe — the already-patched
  check detects the injected `||` condition and skips.

## No regressions

| Case | Before patch | After patch |
|------|-------------|-------------|
| `scope="user"` plugins | shown under Personal Plugins | unchanged |
| `scope="project"` with real projectPath | shown under project header | unchanged — falls through to existing block |
| `scope="project"` with projectPath=$HOME | shown under project header (bug) | shown under Personal Plugins (fixed) |
| `scope="local"` plugins | shown under project header | unchanged — not touched by this patch |

The only behavioral change is for the specific case this patch targets.
`path.normalize` handles trailing-slash edge cases safely, and `require("path")`
is available in Electron's main process context.

## Testing

Tested on Fedora 44 (Wayland/GNOME) with `claude-desktop-bin-1.5354.0-2`.
All CLI-installed personal plugins now appear correctly under "Personal Plugins".